### PR TITLE
Installing tower cli from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ RUN rpm --import /tmp/centos-key && \
     yum-config-manager --add-repo=http://mirror.centos.org/centos/7/updates/x86_64/ && \
     rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     yum -y install unzip httpd-tools java-1.8.0-openjdk-headless dh-autoreconf && \
+    sh -c "git clone https://github.com/ansible/tower-cli.git ; cd tower-cli ; make install" && \
     sh -c "tar -xzf /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit.tar.gz -C /tmp/" && \
     sh -c "mv /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit/oc /usr/bin/oc" && \ 
     sh -c "rm /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit.tar.gz" && \
-    sh -c ". /var/lib/awx/venv/awx/bin/activate ; pip install openshift ansible-tower-cli" && \
+    sh -c ". /var/lib/awx/venv/awx/bin/activate" && \
     chmod 755 /usr/bin/yq /usr/bin/jq /usr/bin/oc
 
 USER awx


### PR DESCRIPTION
**Summary**
Installing Tower CLI from source rather than Pip. Also removing openshift package install as it's no longer required.