### PR TITLE
Including tower login prior to bootstrap

### DIFF
--- a/playbooks/roles/tower/tasks/bootstrap.yml
+++ b/playbooks/roles/tower/tasks/bootstrap.yml
@@ -1,4 +1,7 @@
 ---
+
+- include_tasks: authenticate.yml
+
 # Bug with Tower module where we need to create an empty scm credential bundle before creating a project
 # https://github.com/ansible/ansible/pull/34250
 - name: "Create SCM credential bundle: {{ tower_credential_bundle_github_name }}"


### PR DESCRIPTION
**Summary**
Including tower authenticate tasks prior to bootstrapping process. The current way expects end users to be logged in before bootstrapping. 

This change will configure tower auth automatically.