### PR TITLE
Dynamically setting AWS creds for Integreatly Workflow survey

### DIFF
--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -74,3 +74,6 @@ integreatly_group_local_update_on_launch: false
 # Integreatly Hosts
 integreatly_host_local_name: 'localhost'
 integreatly_host_local_desc: "Localhost: {{ cluster_name }}"
+
+# Integreatly Survey
+integreatly_install_survey_aws_accounts: []

--- a/playbooks/roles/integreatly/tasks/workflow.yml
+++ b/playbooks/roles/integreatly/tasks/workflow.yml
@@ -32,6 +32,27 @@
     state: present
     inventory: "{{ tower_inventory_name }}"
 
+- name: Retrieve AWS Credential Type ID
+  shell: "tower-cli credential_type list --kind cloud -n \"Amazon Web Services\" -f id"
+  register: aws_cred_type_id
+
+- name: Retrieve list of AWS Credential Bundles
+  shell: "tower-cli credential list --credential-type {{ aws_cred_type_id.stdout }} -f json"
+  register: aws_credentials_raw
+
+- set_fact:
+    aws_credentials_json: "{{ aws_credentials_raw.stdout | from_json }}"
+    integreatly_aws_accounts: []
+
+- name: "Set list of Integreatly AWS Accounts"
+  set_fact:
+    integreatly_aws_accounts: "{{ integreatly_aws_accounts + [ item.name ] }}"
+  with_items: "{{ aws_credentials_json.results }}"
+  no_log: true
+
+- set_fact:
+    integreatly_install_survey_aws_accounts: "{{ integreatly_aws_accounts | join('\\n')}}"
+
 - name: "Create workflow: {{ integreatly_workflow_job_template_name }}"
   tower_workflow_template:
     name:  "{{ integreatly_workflow_job_template_name }}"
@@ -42,10 +63,22 @@
 - name: Create workflow schema
   template:
     src: workflow_schema.yml.j2
-    dest: "integreatly_workflow_schema.yml"
+    dest: "/tmp/integreatly_workflow_schema.yml"
+
+- name: Create workflow survey
+  template:
+    src: workflow_survey.json.j2
+    dest: "/tmp/workflow_survey.json"
 
 - name: "Update Workflow job template with survey"
-  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_job_template_name }}\" --survey-enabled=true --survey-spec='@{{ role_path }}/templates/workflow_survey.json'"
+  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_survey.json'"
 
 - name: "Update Workflow job template with schema"
-  shell: "tower-cli workflow schema \"{{ integreatly_workflow_job_template_name }}\" @integreatly_workflow_schema.yml"
+  shell: "tower-cli workflow schema \"{{ integreatly_workflow_job_template_name }}\" @/tmp/integreatly_workflow_schema.yml"
+
+- name: Cleanup temp workflow files
+  file:
+    path: "{{ item }}"
+  with_items:
+    - /tmp/integreatly_workflow_schema.yml
+    - /tmp/workflow_survey.json

--- a/playbooks/roles/integreatly/templates/workflow_survey.json.j2
+++ b/playbooks/roles/integreatly/templates/workflow_survey.json.j2
@@ -98,15 +98,15 @@
       },
       {
         "question_description": "AWS Account Credentials",
-        "min": 0,
-        "default": "coreos",
-        "max": 1024,
+        "min": null,
+        "default": "",
+        "max": null,
         "required": true,
-        "choices": "",
+        "choices": "{{ integreatly_install_survey_aws_accounts }}",
         "new_question": true,
         "variable": "integreatly_inventory_source_aws_credentials",
         "question_name": "AWS Credentials",
-        "type": "text"
+        "type": "multiplechoice"
       }
     ]
   }


### PR DESCRIPTION
**Summary**
Removing hardcoded entry of CoreOS
Adding logic to dynamically set AWS account options on the Integreatly install workflow survey

**Validation**
```
ansible-playbook -i inventory/hosts playbooks/bootstrap_integreatly.yml
```
* From the tower console, select the template named "Integreatly Install Workflow"
* The 'AWS Credentials' field on the workflow survey should set options based on the AWS credential bundles that exist on that tower instance 