### PR TITLE
Adding extra var template to read in cluster config details

### DIFF
--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -3,6 +3,10 @@
 # Cluster Configurations
 cluster_name: ''
 cluster_type: 'poc' # (poc|rhpds|dev)
+cluster_provisioning_vars_inventory: "{{ cluster_name }}_provisioning_vars"
+cluster_aws_region: ''
+cluster_aws_access_key: ''
+cluster_aws_secret_access_key: ''
 
 # Workflow Job Template
 integreatly_workflow_job_template_name: 'Integreatly Install Workflow'

--- a/playbooks/roles/integreatly/files/extra_vars_poc.yml
+++ b/playbooks/roles/integreatly/files/extra_vars_poc.yml
@@ -1,7 +1,0 @@
----
-ansible_user: root
-openshift_login: true
-prerequisites_install: false
-threescale_pvc_rwx_storageclassname: nfs
-che_persistent_volume_storageclassname: nfs
-create_cluster_admin: false

--- a/playbooks/roles/integreatly/tasks/bootstrap.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap.yml
@@ -108,5 +108,29 @@
   retries: 10
   delay: 5
 
+- name: Retrieve cluster provisioning vars inventory
+  shell: "tower-cli inventory get -n \"{{ cluster_provisioning_vars_inventory }}\" -f json"
+  register: cluster_provisioning_vars_raw
+
+- set_fact:
+    cluster_provisioning_vars_json: "{{ cluster_provisioning_vars_raw.stdout | from_json }}"
+
+- set_fact:
+    cluster_provisioning_vars: "{{ cluster_provisioning_vars_json.variables }}"
+
+- set_fact:
+    cluster_aws_region: "{{ cluster_provisioning_vars['openshift_aws_region'] }}"
+    cluster_aws_access_key: "{{ cluster_provisioning_vars['AWS_ACCESS_KEY_ID'] }}"
+    cluster_aws_secret_access_key: "{{ cluster_provisioning_vars['AWS_SECRET_ACCESS_KEY'] }}"
+
+- name: Generate extra vars file
+  template:
+    dest: "/tmp/extra_vars_{{ cluster_type }}.yml"
+    src: "extra_vars_{{ cluster_type }}.yml.j2"
+
 - name: "Update workflow stage {{ integreatly_job_template_deploy_name }}"
-  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_deploy_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_bootstrap_cluster_name }} --playbook {{ integreatly_job_template_deploy_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@{{ role_path }}/files/extra_vars_{{ cluster_type }}.yml'"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_deploy_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_bootstrap_cluster_name }} --playbook {{ integreatly_job_template_deploy_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@/tmp/extra_vars_{{ cluster_type }}.yml'"
+
+- name: Cleanup temp var file
+  file:
+    path: "/tmp/extra_vars_{{ cluster_type }}.yml"

--- a/playbooks/roles/integreatly/tasks/workflow.yml
+++ b/playbooks/roles/integreatly/tasks/workflow.yml
@@ -70,10 +70,10 @@
     src: workflow_survey.json.j2
     dest: "/tmp/workflow_survey.json"
 
-- name: "Update Workflow job template with survey"
+- name: Update workflow job template with survey
   shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_survey.json'"
 
-- name: "Update Workflow job template with schema"
+- name: Update workflow job template with schema
   shell: "tower-cli workflow schema \"{{ integreatly_workflow_job_template_name }}\" @/tmp/integreatly_workflow_schema.yml"
 
 - name: Cleanup temp workflow files

--- a/playbooks/roles/integreatly/templates/extra_vars_poc.yml.j2
+++ b/playbooks/roles/integreatly/templates/extra_vars_poc.yml.j2
@@ -1,0 +1,12 @@
+---
+ansible_user: root
+openshift_login: true
+prerequisites_install: false
+create_cluster_admin: false
+
+# 3scale
+threescale_file_upload_storage: s3
+threescale_storage_s3_aws_access_key: "{{ cluster_aws_access_key }}"
+threescale_storage_s3_aws_secret_key: "{{ cluster_aws_secret_access_key }}"
+threescale_storage_s3_aws_region: "{{ cluster_aws_region }}"
+threescale_storage_s3_aws_bucket: "{{ cluster_name }}-3scale"


### PR DESCRIPTION
**Summary**
Retrieving Cluster details from the cluster provisioning vars inventory in order to configure 3scale with the generated S3 bucket during integreatly installs

**Validation**
* Bootstrap tower instance as normal
* Run Integreatly Install workflow against an existing POC cluster (one that has a provisioning_vars inventory file on tower)