### PR TITLE
Support integreatly uninstall

### DIFF
--- a/playbooks/bootstrap_integreatly_cleandown.yml
+++ b/playbooks/bootstrap_integreatly_cleandown.yml
@@ -1,0 +1,9 @@
+---
+- hosts: local
+  gather_facts: no
+  tasks:
+    - include_vars:
+        ./roles/tower/defaults/main.yml
+    - include_role:
+        name: integreatly
+        tasks_from: bootstrap_cleandown.yml

--- a/playbooks/bootstrap_integreatly_uninstall.yml
+++ b/playbooks/bootstrap_integreatly_uninstall.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_vars:
+        ./roles/tower/defaults/main.yml
+    - include_role:
+        name: integreatly
+        tasks_from: bootstrap_uninstall.yml

--- a/playbooks/roles/cluster/tasks/bootstrap_cluster_create.yml
+++ b/playbooks/roles/cluster/tasks/bootstrap_cluster_create.yml
@@ -5,6 +5,7 @@
     description: "Floating inventory for cluster create workflow"
     organization: "{{ tower_organization }}"
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: "Sync inventory sources"
   shell: "tower-cli inventory_source update {{ cluster_inventory_source_project_name }}"
@@ -13,6 +14,7 @@
   tower_organization:
     name: "{{ tower_secret_organization }}"
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: "Create project: Openshift Ansible"
   tower_project:
@@ -27,6 +29,7 @@
     scm_update_on_launch: "{{ cluster_project_bootstrap_cluster_scm_update_on_launch }}"
     scm_delete_on_update: "{{ cluster_project_bootstrap_cluster_scm_delete_on_update }}"
     scm_credential: "{{ cluster_credential_bundle_github_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: "Create le_privatekey custom credential"
   tower_credential_type:
@@ -35,3 +38,4 @@
     injectors: {'extra_vars': {'le_private_key': "{{ lookup('file', 'LE_privatekey_template') }}" }}
     state: present
     kind: cloud
+    tower_verify_ssl: '{{ tower_verify_ssl }}'

--- a/playbooks/roles/cluster/tasks/bootstrap_cluster_create.yml
+++ b/playbooks/roles/cluster/tasks/bootstrap_cluster_create.yml
@@ -6,25 +6,12 @@
     organization: "{{ tower_organization }}"
     state: present
 
-- name: "Create inventory source from Project: {{ tower_credentials_project_name}}"
-  tower_inventory_source:
-    name: "{{ cluster_inventory_source_project_name }}"
-    source: "{{ cluster_inventory_source_project_type }}"
-    inventory: "{{ tower_inventory_name }}"
-    description: "From Project: {{ tower_credentials_project_name }}"
-    overwrite: "{{ cluster_inventory_source_project_overwrite }}"
-    overwrite_vars: "{{ cluster_inventory_source_project_overwrite_vars }}"
-    update_on_launch: "{{ cluster_inventory_source_project_update_on_launch }}"
-    source_project: "{{ tower_credentials_project_name }}"
-    source_path: "{{ cluster_inventory_source_project_path }}"
-    state: present
-
 - name: "Sync inventory sources"
   shell: "tower-cli inventory_source update {{ cluster_inventory_source_project_name }}"
 
-- name: 'Create the secret organisation'
+- name: "Create the tower {{ tower_secret_organization }} organisation"
   tower_organization:
-    name: 'secret'
+    name: "{{ tower_secret_organization }}"
     state: present
 
 - name: "Create project: Openshift Ansible"

--- a/playbooks/roles/cluster/tasks/workflow.yml
+++ b/playbooks/roles/cluster/tasks/workflow.yml
@@ -10,7 +10,8 @@
     extra_vars_path: "roles/cluster/files/openshift_tower_auth.yml"
     vault_credential: "{{ tower_credential_bundle_vault_name }}"
     state: present
-    inventory: "{{ tower_inventory_name }}"
+    inventory: "Provisioning_inventory"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_openshift_auth_out
   until: cluster_create_openshift_auth_out is succeeded
   retries: 10
@@ -26,7 +27,8 @@
     credential: "{{ tower_credential_bundle_default_name }}"
     vault_credential: "{{ tower_credential_bundle_vault_name }}"
     state: present
-    inventory: "{{ tower_inventory_name }}"
+    inventory: "Provisioning_inventory"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_generate_inventory_out
   until: cluster_create_generate_inventory_out is succeeded
   retries: 10
@@ -52,7 +54,8 @@
     credential: "{{ tower_credential_bundle_default_name }}"
     vault_credential: "{{ tower_credential_bundle_vault_name }}"
     state: present
-    inventory: "{{ tower_inventory_name }}"
+    inventory: "Provisioning_inventory"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_pre_flight_out
   until: cluster_create_pre_flight_out is succeeded
   retries: 10
@@ -74,6 +77,7 @@
     credential: "{{ tower_credential_bundle_default_name }}"
     state: present
     inventory: "Provisioning_inventory"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_prerequisites_out
   until: cluster_create_prerequisites_out is succeeded
   retries: 10
@@ -92,6 +96,7 @@
     credential: "{{ tower_credential_bundle_default_name }}"
     state: present
     inventory: "Provisioning_inventory"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_provision_install_out
   until: cluster_create_provision_install_out is succeeded
   retries: 10
@@ -113,6 +118,7 @@
     credential: "{{ tower_credential_bundle_default_name }}"
     state: present
     inventory: "Provisioning_inventory"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_post_install_out
   until: cluster_create_post_install_out is succeeded
   retries: 10
@@ -124,6 +130,7 @@
     description: "{{ cluster_workflow_job_template_desc }}"
     state: present
     organization: "{{ tower_organization }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: Create workflow schema
   template:

--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -3,43 +3,75 @@
 # Cluster Configurations
 cluster_name: ''
 cluster_type: 'poc' # (poc|rhpds|dev)
-cluster_provisioning_vars_inventory: "{{ cluster_name }}_provisioning_vars"
+cluster_provisioning_vars_inventory: "{{ cluster_name }}"
 cluster_aws_region: ''
 cluster_aws_access_key: ''
 cluster_aws_secret_access_key: ''
 
 # Workflow Job Template
-integreatly_workflow_job_template_name: 'Integreatly Install Workflow'
-integreatly_workflow_job_template_desc: 'Workflow for Installing Integreatly against a target Openshift Cluster'
-integreatly_workflow_job_template_organization: "{{ tower_organization }}"
+integreatly_workflow_install_job_template_name: 'Integreatly Install Workflow'
+integreatly_workflow_install_job_template_desc: 'Workflow for Installing Integreatly on Openshift'
+integreatly_workflow_install_job_template_organization: "{{ tower_organization }}"
+
+integreatly_workflow_uninstall_job_template_name: 'Integreatly Uninstall Workflow'
+integreatly_workflow_uninstall_job_template_desc: 'Workflow for Uninstalling Integreatly on Openshift'
+integreatly_workflow_uninstall_job_template_organization: "{{ tower_organization }}"
 
 # Integreatly Credentials
 integreatly_credential_bundle_github_name: "tower_github_scm"
 integreatly_credential_bundle_github_desc: "SCM credentials for Integreatly project"
 integreatly_credential_bundle_github_kind: 'scm'
 
-# Integreatly Job Templates
-integreatly_job_template_bootstrap_name: 'Integreatly Bootstrap Cluster Template'
-integreatly_job_template_bootstrap_desc: 'Job for bootstrapping integreatly cluster resources'
-integreatly_job_template_bootstrap_type: 'run'
-integreatly_job_template_bootstrap_playbook: 'playbooks/bootstrap_integreatly_install.yml'
-integreatly_job_template_bootstrap_credentials: "{{ tower_credential_bundle_default_name }}"
+# Integreatly Job Templates: Install
+integreatly_job_template_bootstrap_install_name: 'Integreatly Bootstrap Install Template'
+integreatly_job_template_bootstrap_install_desc: 'Job for bootstrapping integreatly cluster resources'
+integreatly_job_template_bootstrap_install_type: 'run'
+integreatly_job_template_bootstrap_install_playbook: 'playbooks/bootstrap_integreatly_install.yml'
+integreatly_job_template_bootstrap_install_credentials: "{{ tower_credential_bundle_default_name }}"
 
-integreatly_job_template_deploy_name: 'Integreatly Deploy Job Template'
-integreatly_job_template_deploy_desc: 'Job for deploying Integreatly on target Openshift cluster'
+integreatly_job_template_deploy_name: 'Integreatly Deploy Template'
+integreatly_job_template_deploy_desc: 'Job for deploying Integreatly on Openshift'
 integreatly_job_template_deploy_type: 'run'
 integreatly_job_template_deploy_playbook: 'playbooks/install.yml'
 integreatly_job_template_deploy_credentials: "{{ tower_credential_bundle_default_name }}"
 
+# Integreatly Job Templates: Uninstall
+integreatly_job_template_uninstall_name: 'Integreatly Uninstall Template'
+integreatly_job_template_uninstall_desc: 'Job for uninstalling Integreatly on Openshift'
+integreatly_job_template_uninstall_type: 'run'
+integreatly_job_template_uninstall_playbook: 'playbooks/uninstall.yml'
+integreatly_job_template_uninstall_credentials: "{{ tower_credential_bundle_default_name }}"
+
+integreatly_job_template_bootstrap_uninstall_name: 'Integreatly Bootstrap Uninstall Template'
+integreatly_job_template_bootstrap_uninstall_desc: 'Job for bootstrapping resources for Integreatly uninstall'
+integreatly_job_template_bootstrap_uninstall_type: 'run'
+integreatly_job_template_bootstrap_uninstall_playbook: 'playbooks/bootstrap_integreatly_uninstall.yml'
+integreatly_job_template_bootstrap_uninstall_credentials: "{{ tower_credential_bundle_default_name }}"
+
+integreatly_job_template_cleandown_name: 'Integreatly Clean Down Template'
+integreatly_job_template_cleandown_desc: 'Job for cleaning down Integreatly resources'
+integreatly_job_template_cleandown_type: 'run'
+integreatly_job_template_cleandown_playbook: 'playbooks/bootstrap_integreatly_cleandown.yml'
+integreatly_job_template_cleandown_credentials: "{{ tower_credential_bundle_default_name }}"
+
 # Integreatly Projects
-integreatly_project_bootstrap_cluster_scm_branch: ''
-integreatly_project_bootstrap_cluster_name: "integreatly-install-{{ integreatly_project_bootstrap_cluster_scm_branch }}"
-integreatly_project_bootstrap_cluster_desc: "Integreatly Project for Branch: {{ integreatly_project_bootstrap_cluster_scm_branch }}"
-integreatly_project_bootstrap_cluster_scm_type: git
-integreatly_project_bootstrap_cluster_scm_clean: true
-integreatly_project_bootstrap_cluster_scm_url: ''
-integreatly_project_bootstrap_cluster_scm_update_on_launch: true
-integreatly_project_bootstrap_cluster_scm_delete_on_update: true
+integreatly_project_install_scm_branch: ''
+integreatly_project_install_name: "integreatly-install-{{ integreatly_project_install_scm_branch }}"
+integreatly_project_install_desc: "Integreatly Project for Branch: {{ integreatly_project_install_scm_branch }}"
+integreatly_project_install_scm_type: git
+integreatly_project_install_scm_clean: true
+integreatly_project_install_scm_url: ''
+integreatly_project_install_scm_update_on_launch: true
+integreatly_project_install_scm_delete_on_update: true
+
+integreatly_project_uninstall_scm_branch: ''
+integreatly_project_uninstall_name: "integreatly-uninstall-{{ integreatly_project_uninstall_scm_branch }}"
+integreatly_project_uninstall_desc: "Integreatly Project for Branch: {{ integreatly_project_uninstall_scm_branch }}"
+integreatly_project_uninstall_scm_type: git
+integreatly_project_uninstall_scm_clean: true
+integreatly_project_uninstall_scm_url: ''
+integreatly_project_uninstall_scm_update_on_launch: true
+integreatly_project_uninstall_scm_delete_on_update: true
 
 # Integreatly Inventories
 integreatly_inventory_name: "{{ cluster_name }}"
@@ -54,7 +86,7 @@ integreatly_inventory_source_aws_credentials: ''
 integreatly_inventory_source_aws_regions: 'All'
 integreatly_inventory_source_aws_instance_filters: "tag:clusterid={{ cluster_name }}"
 
-integreatly_inventory_source_project_name: "{{ cluster_name }}-inventory-source-project-{{ integreatly_project_bootstrap_cluster_name }}"
+integreatly_inventory_source_project_name: "{{ cluster_name }}-inventory-source-project-{{ integreatly_project_install_name }}"
 integreatly_inventory_source_project_type: 'scm'
 integreatly_inventory_source_project_path: "inventories/"
 integreatly_inventory_source_project_update_on_launch: false

--- a/playbooks/roles/integreatly/tasks/bootstrap.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap.yml
@@ -9,76 +9,8 @@
     organization: "{{ tower_organization }}"
     state: present
     kind: "{{ integreatly_credential_bundle_github_kind }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
-- name: "Configure Bootstrap Cluster job template: {{ integreatly_job_template_bootstrap_name }}"
-  tower_job_template:
-    name: "{{ integreatly_job_template_bootstrap_name }}"
-    description: "{{ integreatly_job_template_bootstrap_desc }}"
-    job_type: "{{ integreatly_job_template_bootstrap_type }}"
-    playbook: "{{ integreatly_job_template_bootstrap_playbook }}"
-    project: "{{ tower_configuration_project_name }}"
-    credential: "{{ tower_credential_bundle_default_name }}"
-    state: present
-    inventory: "{{ tower_inventory_name }}"
+- include_tasks: workflow_install.yml
 
-- name: "Configure Deploy Integreatly job template: {{ integreatly_job_template_deploy_name }}"
-  tower_job_template:
-    name: "{{ integreatly_job_template_deploy_name }}"
-    description: "{{ integreatly_job_template_deploy_desc }}"
-    job_type: "{{ integreatly_job_template_deploy_type }}"
-    playbook: "{{ integreatly_job_template_bootstrap_playbook }}"
-    project: "{{ tower_configuration_project_name }}"
-    credential: "{{ tower_credential_bundle_default_name }}"
-    state: present
-    inventory: "{{ tower_inventory_name }}"
-
-- name: Retrieve AWS Credential Type ID
-  shell: "tower-cli credential_type list --kind cloud -n \"Amazon Web Services\" -f id"
-  register: aws_cred_type_id
-
-- name: Retrieve list of AWS Credential Bundles
-  shell: "tower-cli credential list --credential-type {{ aws_cred_type_id.stdout }} -f json"
-  register: aws_credentials_raw
-
-- set_fact:
-    aws_credentials_json: "{{ aws_credentials_raw.stdout | from_json }}"
-    integreatly_aws_accounts: []
-
-- name: "Set list of Integreatly AWS Accounts"
-  set_fact:
-    integreatly_aws_accounts: "{{ integreatly_aws_accounts + [ item.name ] }}"
-  with_items: "{{ aws_credentials_json.results }}"
-  no_log: true
-
-- set_fact:
-    integreatly_install_survey_aws_accounts: "{{ integreatly_aws_accounts | join('\\n')}}"
-
-- name: "Create workflow: {{ integreatly_workflow_job_template_name }}"
-  tower_workflow_template:
-    name:  "{{ integreatly_workflow_job_template_name }}"
-    description: "{{ integreatly_workflow_job_template_desc }}"
-    state: present
-    organization: "{{ integreatly_workflow_job_template_organization }}"
-
-- name: Create workflow schema
-  template:
-    src: workflow_schema.yml.j2
-    dest: "/tmp/integreatly_workflow_schema.yml"
-
-- name: Create workflow survey
-  template:
-    src: workflow_survey.json.j2
-    dest: "/tmp/workflow_survey.json"
-
-- name: Update workflow job template with survey
-  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_survey.json'"
-
-- name: Update workflow job template with schema
-  shell: "tower-cli workflow schema \"{{ integreatly_workflow_job_template_name }}\" @/tmp/integreatly_workflow_schema.yml"
-
-- name: Cleanup temp workflow files
-  file:
-    path: "{{ item }}"
-  with_items:
-    - /tmp/integreatly_workflow_schema.yml
-    - /tmp/workflow_survey.json
+- include_tasks: workflow_uninstall.yml

--- a/playbooks/roles/integreatly/tasks/bootstrap_cleandown.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_cleandown.yml
@@ -1,0 +1,11 @@
+---
+
+- name: "Delete project: {{ item }}"
+  tower_project:
+    name: "{{ item }}"
+    organization: "{{ tower_organization }}"
+    state: absent
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+  with_items:
+    - "{{ integreatly_project_install_name  }}"
+    - "{{ integreatly_project_uninstall_name  }}"

--- a/playbooks/roles/integreatly/tasks/bootstrap_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_install.yml
@@ -4,22 +4,24 @@
   tower_inventory:
     name: "{{ integreatly_inventory_name }}"
     description: "{{ integreatly_inventory_desc }}"
-    organization: "{{ tower_organization }}"
+    organization: "{{ tower_secret_organization }}"
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
-- name: "Create project: {{ integreatly_project_bootstrap_cluster_name }}"
+- name: "Create project: {{ integreatly_project_install_name }}"
   tower_project:
-    name: "{{ integreatly_project_bootstrap_cluster_name }}"
-    description: "{{ integreatly_project_bootstrap_cluster_desc }}"
+    name: "{{ integreatly_project_install_name }}"
+    description: "{{ integreatly_project_install_desc }}"
     organization: "{{ tower_organization }}"
     state: present
-    scm_type: "{{ integreatly_project_bootstrap_cluster_scm_type }}"
-    scm_url: "{{ integreatly_project_bootstrap_cluster_scm_url }}"
-    scm_branch: "{{ integreatly_project_bootstrap_cluster_scm_branch }}"
-    scm_clean: "{{ integreatly_project_bootstrap_cluster_scm_clean }}"
-    scm_update_on_launch: "{{ integreatly_project_bootstrap_cluster_scm_update_on_launch }}"
-    scm_delete_on_update: "{{ integreatly_project_bootstrap_cluster_scm_delete_on_update }}"
+    scm_type: "{{ integreatly_project_install_scm_type }}"
+    scm_url: "{{ integreatly_project_install_scm_url }}"
+    scm_branch: "{{ integreatly_project_install_scm_branch }}"
+    scm_clean: "{{ integreatly_project_install_scm_clean }}"
+    scm_update_on_launch: "{{ integreatly_project_install_scm_update_on_launch }}"
+    scm_delete_on_update: "{{ integreatly_project_install_scm_delete_on_update }}"
     scm_credential: "{{ integreatly_credential_bundle_github_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: "Create inventory source AWS: {{ integreatly_inventory_source_aws_name }}"
   tower_inventory_source:
@@ -33,19 +35,21 @@
     update_on_launch: "{{ integreatly_inventory_source_aws_update_on_launch }}"
     instance_filters: "{{ integreatly_inventory_source_aws_instance_filters }}"
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
-- name: "Create inventory source from Project: {{ integreatly_project_bootstrap_cluster_name }}"
+- name: "Create inventory source from Project: {{ integreatly_project_install_name }}"
   tower_inventory_source:
     name: "{{ integreatly_inventory_source_project_name }}"
     source: "{{ integreatly_inventory_source_project_type }}"
     inventory: "{{ integreatly_inventory_name }}"
-    description: "From Project: {{ integreatly_project_bootstrap_cluster_name }}"
+    description: "From Project: {{ integreatly_project_install_name }}"
     overwrite: "{{ integreatly_inventory_source_project_overwrite }}"
     overwrite_vars: "{{ integreatly_inventory_source_project_overwrite_vars }}"
     update_on_launch: "{{ integreatly_inventory_source_project_update_on_launch }}"
-    source_project: "{{ integreatly_project_bootstrap_cluster_name }}"
+    source_project: "{{ integreatly_project_install_name }}"
     source_path: "{{ integreatly_inventory_source_project_path }}"
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: "Sync inventory sources"
   shell: "tower-cli inventory_source update {{ item }}"
@@ -62,6 +66,7 @@
     overwrite: "{{ integreatly_group_master_overwrite }}"
     overwrite_vars: "{{ integreatly_group_master_overwrite_vars }}"
     update_on_launch: "{{ integreatly_group_master_update_on_launch }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: master_group_data
 
 - name: "Retrieve tag_host_type_master group data"
@@ -96,6 +101,7 @@
     inventory: "{{ integreatly_inventory_name }}"
     description: "{{ integreatly_host_local_desc }}"
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: local_host_data
 
 - name: "Associate {{ integreatly_host_local_name }} with group {{ integreatly_group_local_name }}"
@@ -125,12 +131,12 @@
 
 - name: Generate extra vars file
   template:
-    dest: "/tmp/extra_vars_{{ cluster_type }}.yml"
-    src: "extra_vars_{{ cluster_type }}.yml.j2"
+    dest: "/tmp/extra_vars_{{ cluster_type }}_install.yml"
+    src: "extra_vars_{{ cluster_type }}_install.yml.j2"
 
 - name: "Update workflow stage {{ integreatly_job_template_deploy_name }}"
-  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_deploy_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_bootstrap_cluster_name }} --playbook {{ integreatly_job_template_deploy_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@/tmp/extra_vars_{{ cluster_type }}.yml'"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_deploy_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_install_name }} --playbook {{ integreatly_job_template_deploy_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@/tmp/extra_vars_{{ cluster_type }}_install.yml'"
 
 - name: Cleanup temp var file
   file:
-    path: "/tmp/extra_vars_{{ cluster_type }}.yml"
+    path: "/tmp/extra_vars_{{ cluster_type }}_install.yml"

--- a/playbooks/roles/integreatly/tasks/bootstrap_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_uninstall.yml
@@ -1,0 +1,28 @@
+---
+
+- name: "Create project: {{ integreatly_project_uninstall_name }}"
+  tower_project:
+    name: "{{ integreatly_project_uninstall_name }}"
+    description: "{{ integreatly_project_uninstall_desc }}"
+    organization: "{{ tower_organization }}"
+    state: present
+    scm_type: "{{ integreatly_project_uninstall_scm_type }}"
+    scm_url: "{{ integreatly_project_uninstall_scm_url }}"
+    scm_branch: "{{ integreatly_project_uninstall_scm_branch }}"
+    scm_clean: "{{ integreatly_project_uninstall_scm_clean }}"
+    scm_update_on_launch: "{{ integreatly_project_uninstall_scm_update_on_launch }}"
+    scm_delete_on_update: "{{ integreatly_project_uninstall_scm_delete_on_update }}"
+    scm_credential: "{{ integreatly_credential_bundle_github_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: Generate extra vars file
+  template:
+    dest: "/tmp/extra_vars_{{ cluster_type }}_uninstall.yml"
+    src: "extra_vars_{{ cluster_type }}_uninstall.yml.j2"
+
+- name: "Update workflow stage {{ integreatly_job_template_uninstall_name }}"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_uninstall_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_uninstall_name }} --playbook {{ integreatly_job_template_uninstall_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@/tmp/extra_vars_{{ cluster_type }}_uninstall.yml'"
+  register: uninstall_workflow_update
+  retries: 10
+  delay: 3
+  until: uninstall_workflow_update.rc == 0

--- a/playbooks/roles/integreatly/tasks/workflow_install.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_install.yml
@@ -1,0 +1,77 @@
+---
+
+- name: "Configure Cluster Bootstrap job template: {{ integreatly_job_template_bootstrap_install_name }}"
+  tower_job_template:
+    name: "{{ integreatly_job_template_bootstrap_install_name }}"
+    description: "{{ integreatly_job_template_bootstrap_install_desc }}"
+    job_type: "{{ integreatly_job_template_bootstrap_install_type }}"
+    playbook: "{{ integreatly_job_template_bootstrap_install_playbook }}"
+    project: "{{ tower_configuration_project_name }}"
+    credential: "{{ integreatly_job_template_bootstrap_install_credentials }}"
+    state: present
+    inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: "Configure Integreatly Deploy job template: {{ integreatly_job_template_deploy_name }}"
+  tower_job_template:
+    name: "{{ integreatly_job_template_deploy_name }}"
+    description: "{{ integreatly_job_template_deploy_desc }}"
+    job_type: "{{ integreatly_job_template_deploy_type }}"
+    playbook: "{{ integreatly_job_template_bootstrap_install_playbook }}"
+    project: "{{ tower_configuration_project_name }}"
+    credential: "{{ integreatly_job_template_deploy_credentials }}"
+    state: present
+    inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: Retrieve AWS Credential Type ID
+  shell: "tower-cli credential_type list --kind cloud -n \"Amazon Web Services\" -f id"
+  register: aws_cred_type_id
+
+- name: Retrieve list of AWS Credential Bundles
+  shell: "tower-cli credential list --credential-type {{ aws_cred_type_id.stdout }} -f json"
+  register: aws_credentials_raw
+
+- set_fact:
+    aws_credentials_json: "{{ aws_credentials_raw.stdout | from_json }}"
+    integreatly_aws_accounts: []
+
+- name: "Set list of Integreatly AWS Accounts"
+  set_fact:
+    integreatly_aws_accounts: "{{ integreatly_aws_accounts + [ item.name ] }}"
+  with_items: "{{ aws_credentials_json.results }}"
+  no_log: true
+
+- set_fact:
+    integreatly_install_survey_aws_accounts: "{{ integreatly_aws_accounts | join('\\n')}}"
+
+- name: "Create workflow: {{ integreatly_workflow_install_job_template_name }}"
+  tower_workflow_template:
+    name:  "{{ integreatly_workflow_install_job_template_name }}"
+    description: "{{ integreatly_workflow_install_job_template_desc }}"
+    state: present
+    organization: "{{ integreatly_workflow_install_job_template_organization }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: Create install workflow schema
+  template:
+    src: workflow_install_schema.yml.j2
+    dest: "/tmp/workflow_install_schema.yml"
+
+- name: Create install workflow survey
+  template:
+    src: workflow_install_survey.json.j2
+    dest: "/tmp/workflow_install_survey.json"
+
+- name: Update install workflow job template with survey
+  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_install_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_install_survey.json'"
+
+- name: Update install workflow job template with schema
+  shell: "tower-cli workflow schema \"{{ integreatly_workflow_install_job_template_name }}\" @/tmp/workflow_install_schema.yml"
+
+- name: Cleanup temp install workflow files
+  file:
+    path: "{{ item }}"
+  with_items:
+    - /tmp/workflow_install_schema.yml
+    - /tmp/workflow_install_survey.json

--- a/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
@@ -1,0 +1,68 @@
+---
+
+- name: "Configure Integreatly Uninstall job template: {{ integreatly_job_template_uninstall_name }}"
+  tower_job_template:
+    name: "{{ integreatly_job_template_uninstall_name }}"
+    description: "{{ integreatly_job_template_uninstall_desc }}"
+    job_type: "{{ integreatly_job_template_uninstall_type }}"
+    playbook: "{{ integreatly_job_template_bootstrap_uninstall_playbook }}"
+    project: "{{ tower_configuration_project_name }}"
+    credential: "{{ integreatly_job_template_uninstall_credentials }}"
+    state: present
+    inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: "Configure Integreatly Bootstrap Uninstall job template: {{ integreatly_job_template_bootstrap_uninstall_name }}"
+  tower_job_template:
+    name: "{{ integreatly_job_template_bootstrap_uninstall_name }}"
+    description: "{{ integreatly_job_template_bootstrap_uninstall_desc }}"
+    job_type: "{{ integreatly_job_template_bootstrap_uninstall_type }}"
+    playbook: "{{ integreatly_job_template_bootstrap_uninstall_playbook }}"
+    project: "{{ tower_configuration_project_name }}"
+    credential: "{{ integreatly_job_template_bootstrap_uninstall_credentials }}"
+    state: present
+    inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: "Configure Cluster Clean Down template: {{ integreatly_job_template_cleandown_name }}"
+  tower_job_template:
+    name: "{{ integreatly_job_template_cleandown_name }}"
+    description: "{{ integreatly_job_template_cleandown_desc }}"
+    job_type: "{{ integreatly_job_template_cleandown_type }}"
+    playbook: "{{ integreatly_job_template_cleandown_playbook }}"
+    project: "{{ tower_configuration_project_name }}"
+    credential: "{{ integreatly_job_template_cleandown_credentials }}"
+    state: present
+    inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: "Create workflow: {{ integreatly_workflow_uninstall_job_template_name }}"
+  tower_workflow_template:
+    name:  "{{ integreatly_workflow_uninstall_job_template_name }}"
+    description: "{{ integreatly_workflow_uninstall_job_template_desc }}"
+    state: present
+    organization: "{{ integreatly_workflow_uninstall_job_template_organization }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: Create uninstall workflow schema
+  template:
+    src: workflow_uninstall_schema.yml.j2
+    dest: "/tmp/workflow_uninstall_schema.yml"
+
+- name: Create uninstall workflow survey
+  template:
+    src: workflow_uninstall_survey.json.j2
+    dest: "/tmp/workflow_uninstall_survey.json"
+
+- name: Update uninstall workflow job template with survey
+  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_uninstall_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_uninstall_survey.json'"
+
+- name: Update uninstall workflow job template with schema
+  shell: "tower-cli workflow schema \"{{ integreatly_workflow_uninstall_job_template_name }}\" @/tmp/workflow_uninstall_schema.yml"
+
+- name: Cleanup temp uninstall workflow files
+  file:
+    path: "{{ item }}"
+  with_items:
+    - /tmp/workflow_uninstall_schema.yml
+    - /tmp/workflow_uninstall_survey.json

--- a/playbooks/roles/integreatly/templates/extra_vars_poc_install.yml.j2
+++ b/playbooks/roles/integreatly/templates/extra_vars_poc_install.yml.j2
@@ -3,6 +3,9 @@ ansible_user: root
 openshift_login: true
 prerequisites_install: false
 create_cluster_admin: false
+backup_restore_install: false
+gitea: false
+ns_prefix: 'openshift-'
 
 # 3scale
 threescale_file_upload_storage: s3

--- a/playbooks/roles/integreatly/templates/extra_vars_poc_uninstall.yml.j2
+++ b/playbooks/roles/integreatly/templates/extra_vars_poc_uninstall.yml.j2
@@ -1,0 +1,6 @@
+---
+ansible_user: root
+openshift_login: true
+prerequisites_install: false
+create_cluster_admin: false
+backup_restore_install: false

--- a/playbooks/roles/integreatly/templates/workflow_install_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/workflow_install_schema.yml.j2
@@ -1,6 +1,6 @@
 ---
 - job_template: "{{ tower_job_template_authenticate_tower_name }}"
   success:
-  - job_template: "{{ integreatly_job_template_bootstrap_name }}"
+  - job_template: "{{ integreatly_job_template_bootstrap_install_name }}"
     success:
     - job_template: "{{ integreatly_job_template_deploy_name }}"

--- a/playbooks/roles/integreatly/templates/workflow_install_survey.json.j2
+++ b/playbooks/roles/integreatly/templates/workflow_install_survey.json.j2
@@ -56,7 +56,7 @@
         "required": true,
         "choices": "",
         "new_question": true,
-        "variable": "integreatly_project_bootstrap_cluster_scm_url",
+        "variable": "integreatly_project_install_scm_url",
         "question_name": "Git URL",
         "type": "text"
       },
@@ -68,7 +68,7 @@
         "required": true,
         "choices": "",
         "new_question": true,
-        "variable": "integreatly_project_bootstrap_cluster_scm_branch",
+        "variable": "integreatly_project_install_scm_branch",
         "question_name": "Git Ref",
         "type": "text"
       },

--- a/playbooks/roles/integreatly/templates/workflow_uninstall_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/workflow_uninstall_schema.yml.j2
@@ -1,0 +1,6 @@
+---
+- job_template: "{{ tower_job_template_authenticate_tower_name }}"
+  success:
+  - job_template: "{{ integreatly_job_template_bootstrap_uninstall_name }}"
+    success:
+    - job_template: "{{ integreatly_job_template_uninstall_name }}"

--- a/playbooks/roles/integreatly/templates/workflow_uninstall_survey.json.j2
+++ b/playbooks/roles/integreatly/templates/workflow_uninstall_survey.json.j2
@@ -1,0 +1,76 @@
+{
+    "description": "",
+    "name": "",
+    "spec": [
+      {
+        "question_description": "Name of target Cluster to Uninstall Integreatly against",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "variable": "cluster_name",
+        "question_name": "Cluster Name",
+        "type": "text"
+      },
+      {
+        "question_description": "The public URL of the target Openshift Cluster",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "variable": "openshift_master_public_url",
+        "question_name": "Openshift Master URL",
+        "type": "text"
+      },
+      {
+        "question_description": "Username of cluster admin account",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "new_question": true,
+        "variable": "openshift_username",
+        "question_name": "Cluster Admin Username",
+        "type": "text"
+      },
+      {
+        "question_description": "Password of cluster admin user",
+        "min": 0,
+        "default": "",
+        "max": 32,
+        "required": true,
+        "choices": "",
+        "new_question": true,
+        "variable": "openshift_password",
+        "question_name": "Cluster Admin Password",
+        "type": "password"
+      },
+      {
+        "question_description": "Integreatly Installer Git URL",
+        "min": 0,
+        "default": "https://github.com/integr8ly/installation.git",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "new_question": true,
+        "variable": "integreatly_project_uninstall_scm_url",
+        "question_name": "Git URL",
+        "type": "text"
+      },
+      {
+        "question_description": "Integreatly Installer Git Ref",
+        "min": 0,
+        "default": "master",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "new_question": true,
+        "variable": "integreatly_project_uninstall_scm_branch",
+        "question_name": "Git Ref",
+        "type": "text"
+      }
+    ]
+  }

--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -14,6 +14,7 @@ tower_openshift_login: true
 
 # Ansible Tower Organizations
 tower_organization: 'integreatly'
+tower_secret_organization: 'secret'
 tower_team: 'integreatly-eng'
 
 # Ansible Tower Credentials

--- a/playbooks/roles/tower/tasks/bootstrap.yml
+++ b/playbooks/roles/tower/tasks/bootstrap.yml
@@ -6,12 +6,14 @@
   tower_organization:
     name: '{{ tower_organization }}'
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Create the {{ tower_team}} team'
   tower_team:
     name: '{{ tower_team }}'
     organization: '{{ tower_organization }}'
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Modify Tower settings to allow authentication via Github'
   shell: '{{ item }}'
@@ -34,6 +36,7 @@
     description: '{{ tower_inventory_desc }}'
     organization: '{{ tower_organization }}'
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Create local host'
   tower_host:
@@ -43,6 +46,7 @@
     variables:
       ansible_connection: local
     state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 
 # Import the credentials bootstrap task

--- a/playbooks/roles/tower/tasks/bootstrap_credentials.yml
+++ b/playbooks/roles/tower/tasks/bootstrap_credentials.yml
@@ -7,6 +7,7 @@
     state: present
     kind: '{{ tower_credential_bundle_vault_type }}'
     vault_password: '{{ integreatly_vault }}'
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Copy the tower_github_scm key to server'
   copy:
@@ -22,6 +23,7 @@
     kind: '{{ tower_credential_bundle_github_type }}'
     ssh_key_data: '/tmp/tower_github_scm'
     ssh_key_unlock: '{{ tower_github_scm_password }}'
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Copy the tower_github_scm key to server'
   copy:
@@ -38,6 +40,7 @@
     ssh_key_data: '/tmp/tower_ssh'
     ssh_key_unlock: '{{ tower_ssh_password }}'
     username: '{{ tower_ssh_user }}'
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Create AWS Credentials'
   tower_credential:
@@ -48,4 +51,5 @@
     kind: '{{ tower_credential_bundle_aws_type }}'
     username: '{{ lookup("vars", "_".join((item, "access_key_id")) ) }}'
     password: '{{ lookup("vars", "_".join((item, "secret_access_key")) ) }}'
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   with_items: '{{ aws_credential_list }}'

--- a/playbooks/roles/tower/tasks/bootstrap_jobs.yml
+++ b/playbooks/roles/tower/tasks/bootstrap_jobs.yml
@@ -10,6 +10,7 @@
     vault_credential: '{{ tower_credential_bundle_vault_name }}'
     state: present
     inventory: '{{ tower_inventory_name }}'
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: tower_job_template_authenticate_tower_raw
   until: tower_job_template_authenticate_tower_raw is succeeded
   retries: 10
@@ -26,6 +27,7 @@
     vault_credential: '{{ tower_credential_bundle_vault_name }}'
     state: present
     inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: openshift_job_template_authenticate_raw
   until: openshift_job_template_authenticate_raw is succeeded
   retries: 10

--- a/playbooks/roles/tower/tasks/bootstrap_projects.yml
+++ b/playbooks/roles/tower/tasks/bootstrap_projects.yml
@@ -12,6 +12,7 @@
     scm_update_on_launch: '{{ tower_configuration_project_scm_update_on_launch }}'
     scm_delete_on_update: '{{ tower_configuration_project_scm_delete_on_update }}'
     scm_credential: '{{ tower_credential_bundle_github_name }}'
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Create project: {{ tower_credentials_project_name }}'
   tower_project:
@@ -26,3 +27,4 @@
     scm_update_on_launch: '{{ tower_credentials_project_scm_update_on_launch }}'
     scm_delete_on_update: '{{ tower_credentials_project_scm_delete_on_update }}'
     scm_credential: '{{ tower_credential_bundle_github_name }}'
+    tower_verify_ssl: '{{ tower_verify_ssl }}'


### PR DESCRIPTION
**Summary**
Adding Integreatly Uninsntall workflow
Setting verify_ssl flag on each tower module block to support self signed cert towers (RHPDS)

**Validation**
Bootstrap tower with integreatly resources
```
ansible-playbook -i  <credential-repo-path>/inventories/hosts playbooks/bootstrap_integreatly.yml --ask-vault-pass
```
- Provision a new cluster via Tower Dev instance
- Install Integreatly via the `Integreatly Install Workflow` template
- Uninstall Integreatly via the `Integreatly Uninstall Workflow` template 