### PR TITLE
Support multiple towers in authentication job

### DIFF
--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 # Ansible Tower Configurations
 tower_login: true
-tower_host: ''
-tower_username: ''
-tower_password: ''
-tower_verify_ssl: false
+tower_environment: "{{ lookup('env','tower_environment') | default('local') }}"
+tower_host: '{{ lookup("vars", "_".join((tower_environment, "tower_host")) ) }}'
+tower_username: '{{ lookup("vars", "_".join((tower_environment, "tower_username")) ) }}'
+tower_password: '{{ lookup("vars", "_".join((tower_environment, "tower_password")) ) }}'
+tower_verify_ssl: '{{ lookup("vars", "_".join((tower_environment, "tower_verify_ssl")) ) }}'
 
 # Ansible Tower Openshift Configurations
 tower_openshift_username: ''


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-1654
Supporting PR: https://github.com/fheng/integreatly_dev/pull/10

Verify:
Pass in a variable `tower_environment="dev"` to access the dev_tower_X variables in integreatly_dev

```
ansible-playbook -i ../integreatly_dev/inventories/hosts playbooks/authenticate_tower.yml -e tower_environment="dev" --ask-vault-pass
```