### PR TITLE
Confirmation checks before cleaning down a tower instance

### DIFF
--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # Ansible Tower Configurations
-tower_login: true
+tower_login: True
+cicd_mode: False
 tower_environment: "{{ lookup('env','tower_environment')}}"
 tower_host: '{{ lookup("vars", "_".join((tower_environment, "tower_host")) ) }}'
 tower_username: '{{ lookup("vars", "_".join((tower_environment, "tower_username")) ) }}'

--- a/playbooks/roles/tower/tasks/cleandown_tower.yml
+++ b/playbooks/roles/tower/tasks/cleandown_tower.yml
@@ -4,10 +4,16 @@
     msg: "tower_environment is not defined"
   when: tower_environment is not defined or tower_environment == ''
 
+- name: 'Check if running in CI/CD mode'
+  set_fact:
+    cleandown_confirmation_prompt: True
+  when: cicd_mode
+
 - name: "Confirmation prompt for cleaning down the > {{ tower_environment }} < tower instance"
   pause:
     prompt: 'Please confirm you want cleandown the {{ tower_environment }} tower instance? (yes/no)'
   register: cleandown_confirmation_prompt
+  when: not cicd_mode
 
 - name: 'Check Confirmation'
   fail:


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-1654

Adds a confirmation check before running the cleandown playbook:
`Please confirm you want cleandown the dev tower instance? (yes/no):`

This behaviour can be overridden when setting `cicd_mode` to `True` which will disable prompts.

Verification:

- When `cicd_mode` is `False`
-- When `tower_environment` is not empty string, or is undefined, playbook will exit
-- Will prompt the user for `(yes|no)`
-- no kills the playbook
-- yes continues the playbook and attempt is made to clean down the environment `tower_environment`

- When `cicd_mode` is `True`
-- When `tower_environment` is not empty string, or is undefined, playbook will exit
-- Will not prompt the user for `(yes|no)`
-- attempt is made to clean down the environment `tower_environment`