### PR TITLE
Displaying tower host on login

### DIFF
--- a/playbooks/roles/tower/tasks/authenticate_tower.yml
+++ b/playbooks/roles/tower/tasks/authenticate_tower.yml
@@ -1,5 +1,5 @@
 ---
-- name: 'Set configuration values'
+- name: "Set configuration values for tower instance: {{ tower_host }}"
   shell: "tower-cli config {{ item }}"
   with_items:
     - "host {{ tower_host }}"


### PR DESCRIPTION
**Summary**
At the moment we're in the dark in terms of what tower host is being logged into by a given job. This change will output the host we're targetting.