### PR TITLE
Add cert and route creation for 3scale wildcard for POC clusters

### DIFF
--- a/playbooks/roles/cluster/files/3scale-wildcard.json.j2
+++ b/playbooks/roles/cluster/files/3scale-wildcard.json.j2
@@ -1,0 +1,40 @@
+{
+    "apiVersion": "route.openshift.io/v1",
+    "kind": "Route",
+    "metadata": {
+        "labels": {
+            "3scale.component": "apicast",
+            "3scale.component-element": "wildcard-router",
+            "app": "3scale-api-management"
+        },
+        "name": "apicast-wildcard-router-integreatly"
+    },
+    "spec": {
+        "host": "wildcard.{{ scale_wildcard_url }}",
+        "port": {
+            "targetPort": "http"
+        },
+        "tls": {
+            "caCertificate": {{ scale_wildcard_ca_certificate_content | to_json }},
+            "certificate": {{ scale_wildcard_certificate_content | to_json }},
+            "insecureEdgeTerminationPolicy": "Allow",
+            "key": {{ scale_wildcard_private_key_content | to_json }},
+            "termination": "edge"
+        },
+        "to": {
+            "kind": "Service",
+            "name": "apicast-wildcard-router",
+            "weight": 100
+        },
+        "wildcardPolicy": "Subdomain"
+    },
+    "status": {
+        "ingress": [
+            {
+              "host": "wildcard.{{ scale_wildcard_url }}",
+              "routerName": "router",
+              "wildcardPolicy": "Subdomain"
+            }
+        ]
+    }
+}

--- a/playbooks/roles/cluster/tasks/cluster_create_generate_inventory.yml
+++ b/playbooks/roles/cluster/tasks/cluster_create_generate_inventory.yml
@@ -57,7 +57,14 @@
 
 - name: set domain variable
   set_fact:
-    domain: "{% if cluster_type is undefined %}{{ dev_domain }}{% elif cluster_type=='POC' %}{{ poc_domain }}{% endif %}"
+    domain: "{% if cluster_type=='dev' %}{{ dev_domain }}{% elif cluster_type=='poc' %}{{ poc_domain }}{% endif %}"
+
+- name: Overwrite DNS task file if neccessary
+  get_url:
+    url: https://raw.githubusercontent.com/StevenTobin/openshift-tools/integreatly_cluster_create_3scale/ansible/roles/oa_aws_provisioning_dns_hook/tasks/main.yml
+    dest: "/tmp/oa_dns_hook/tasks/main.yml"
+    force: yes
+  when: cluster_type == 'poc'
 
 - name: create the provisioning_vars.yml
   template:

--- a/playbooks/roles/cluster/tasks/cluster_create_pre_flight.yml
+++ b/playbooks/roles/cluster/tasks/cluster_create_pre_flight.yml
@@ -6,12 +6,16 @@
 
   - name: set domain variable
     set_fact:
-      domain: "{% if cluster_type is undefined %}{{ dev_domain }}{% elif cluster_type=='POC' %}{{ poc_domain }}{% endif %}"
+      domain: "{% if cluster_type=='dev' %}{{ dev_domain }}{% elif cluster_type=='poc' %}{{ poc_domain }}{% endif %}"
 
   - name: Set urls
     set_fact:
       base_cluster_url: "{{ oo_clusterid }}.{{ domain }}"
       apps_cluster_url: "apps.{{ oo_clusterid }}.{{ domain }}"
+
+  - name: set 3scale wildcard URL
+    set_fact:
+      scale_wildcard_url: "amp.{{ oo_clusterid }}.{{ domain }}"
 
   - name: Check if certificates exist
     stat:
@@ -23,6 +27,9 @@
 
   - stat: path=/tmp/{{ oo_clusterid }}/certs/rootCA.pem
     register: rootca_result
+
+  - stat: path=/tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt
+    register: scale_wildcard_result
 
   - name: Make sure account exists and has given contacts. We agree to TOS.
     acme_account:
@@ -60,6 +67,17 @@
           common_name: "{{ apps_cluster_url }}"
           subject_alt_name: 'DNS:{{ apps_cluster_url }},DNS:*.{{ apps_cluster_url }}'
     when: app_crt_result.stat.exists == false
+
+  - name: Generate a private key and csr for the 3scale wildcard cert
+    block:
+      - openssl_privatekey:
+          path: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.key
+      - openssl_csr:
+          privatekey_path: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.key
+          path: "/tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.csr"
+          common_name: "{{ scale_wildcard_url }}"
+          subject_alt_name: 'DNS:{{ scale_wildcard_url }},DNS:*.{{ scale_wildcard_url }}'
+    when: scale_wildcard_result.stat.exists == false
 
   #
   # Generate <clustername>.<domain> certs
@@ -171,6 +189,74 @@
           overwrite: true
     when: app_crt_result.stat.exists == false
 
+  #
+  # Generate 3scale-wildcard cert
+  #
+
+  - name: Generate "{{ scale_wildcard_url }}" cert
+    block:
+      - acme_certificate:
+          account_key_content: "{{ letsencrypt_private_key }}"
+          account_email: "integreatly-sre@redhat.com"
+          acme_version: 2
+          src: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.csr
+          dest: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt
+          challenge: dns-01
+          acme_directory: https://acme-v02.api.letsencrypt.org/directory
+        register: scale_wildcard_challenge
+      - set_fact:
+          challenges:
+          - "{{ scale_wildcard_challenge.challenge_data[scale_wildcard_url]['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
+          - "{{ scale_wildcard_challenge.challenge_data['*.' + scale_wildcard_url]['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
+      - set_fact:
+          scale_wildcard_dns_challenge: "{{ challenges | join(',') }}"
+      - route53:
+          zone: "{{ domain }}"
+          record: "{{ scale_wildcard_challenge.challenge_data[scale_wildcard_url]['dns-01'].record }}"
+          type: TXT
+          ttl: 60
+          state: present
+          value: "{{ scale_wildcard_dns_challenge }}"
+          aws_access_key: "{{ dns_access_key | default(aws_access_key) }}"
+          aws_secret_key: "{{ dns_secret_key | default(aws_secret_key) }}"
+          wait: yes
+        when: scale_wildcard_challenge is changed
+      - acme_certificate:
+          account_key_content: "{{ letsencrypt_private_key }}"
+          account_email: "integreatly-sre@redhat.com"
+          acme_version: 2
+          src: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.csr
+          cert: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt
+          chain: /tmp/{{ oo_clusterid }}/certs/scale-rootCA.pem
+          challenge: dns-01
+          acme_directory: https://acme-v02.api.letsencrypt.org/directory
+          remaining_days: 60
+          data: "{{ scale_wildcard_challenge }}"
+      - route53:
+          zone: "{{ domain }}"
+          record: "{{ scale_wildcard_challenge.challenge_data[scale_wildcard_url]['dns-01'].record }}"
+          value: "{{ scale_wildcard_dns_challenge }}"
+          type: TXT
+          ttl: 60
+          state: absent
+          aws_access_key: "{{ dns_access_key | default(aws_access_key) }}"
+          aws_secret_key: "{{ dns_secret_key | default(aws_secret_key) }}"
+          overwrite: true
+    when: scale_wildcard_result.stat.exists == false and cluster_type == 'poc'
+
+  - name: Get 3scale wildcard cert contents
+    set_fact:
+      scale_wildcard_ca_certificate_content: "{{ lookup('file', '/tmp/{{ oo_clusterid }}/certs/scale-rootCA.pem') }}"
+      scale_wildcard_certificate_content: "{{ lookup('file', '/tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt') }}"
+      scale_wildcard_private_key_content: "{{ lookup('file', '/tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.key') }}"
+    when: cluster_type == 'poc'
+
+  - name: Generate 3scale wildcard route template
+    template:
+      src: files/3scale-wildcard.json.j2
+      dest: /tmp/{{ oo_clusterid }}/3scale-wildcard-route.json
+    when: cluster_type == 'poc'
+
   - name: Create a bucket for backups
     aws_s3:
       aws_access_key: "{{ aws_access_key }}"
@@ -191,6 +277,16 @@
     with_items:
       - "{{ apps_cluster_url }}"
       - "{{ base_cluster_url }}"
+
+  - name: Backup 3scale cert to bucket if it exists
+    aws_s3:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      bucket: "{{ cluster_backup_bucket_name }}"
+      object: /certs/{{ oo_clusterid }}/wildcard.{{ scale_wildcard_url }}.crt
+      src: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt
+      mode: put
+    when: cluster_type == 'poc'
 
   - name: Backup keys to bucket
     aws_s3:


### PR DESCRIPTION
* Generate letsencrypt certs for 3scale wildcard route
* Use certs to generate route template for wildcard route
* Copy different DNS task to create DNS entry to support wildcard route

The actual creation of the template generated here will have to be done as part of an integreatly-post-install playbook, as the namespaces haven't been created yet at cluster provision time.