### PR TITLE
add the cluster teardown bootstrap to the bootstrap playbook

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -2,3 +2,4 @@
 - import_playbook: "./bootstrap_tower.yml"
 - import_playbook: "./bootstrap_integreatly.yml"
 - import_playbook: "./bootstrap_cluster_create.yml"
+- import_playbook: "./bootstrap_cluster_teardown.yml"


### PR DESCRIPTION
Add the `bootstrap_cluster_teardown.yml` playbook to the `bootstrap.yml` playbook to ensure that all workflow/job templates for the cluster teardown are included.