### PR TITLE
Configurable node counts for cluster provisions

### DIFF
--- a/playbooks/roles/cluster/templates/workflow_survey.json
+++ b/playbooks/roles/cluster/templates/workflow_survey.json
@@ -1,51 +1,84 @@
 {
-    "description": "",
-    "name": "",
-    "spec": [
-      {
-        "question_description": "Desired name of Openshift cluster",
-        "min": 0,
-        "default": "",
-        "max": 16,
-        "required": true,
-        "choices": "",
-        "variable": "oo_clusterid",
-        "question_name": "Cluster Name",
-        "type": "text"
-      },
-      {
-        "question_description": "AWS account name",
-        "min": 0,
-        "default": "fheng.AWS",
-        "max": 100,
-        "required": false,
-        "choices": "{{ cluster_install_survey_aws_accounts }}",
-        "variable": "cluster_credential_bundle_aws_name",
-        "question_name": "AWS account name",
-        "type": "text"
-      },
-      {
-        "question_description": "Region you wish to provision the cluster in",
-        "min": null,
-        "default": "",
-        "max": null,
-        "required": true,
-        "choices": "us-east-1\neu-west-1\neu-west-2",
-        "variable": "oo_sublocation",
-        "question_name": "AWS Region",
-        "type": "multiplechoice"
-      },
-      {
-        "question_description": "Flag for provisioning logging stack",
-        "min": null,
-        "default": "",
-        "max": null,
-        "required": true,
-        "choices": "true\nfalse",
-        "new_question": true,
-        "variable": "survey_provision_logging",
-        "question_name": "Provision Logging",
-        "type": "multiplechoice"
-      }
-    ]
-  }
+  "description": "",
+  "name": "",
+  "spec": [
+    {
+      "question_description": "Desired name of Openshift cluster",
+      "min": 0,
+      "default": "",
+      "max": 16,
+      "required": true,
+      "choices": "",
+      "variable": "oo_clusterid",
+      "question_name": "Cluster Name",
+      "type": "text"
+    },
+    {
+      "question_description": "AWS account name",
+      "min": 0,
+      "default": "fheng.AWS",
+      "max": 100,
+      "required": false,
+      "choices": "{{ cluster_install_survey_aws_accounts }}",
+      "variable": "cluster_credential_bundle_aws_name",
+      "question_name": "AWS account name",
+      "type": "text"
+    },
+    {
+      "question_description": "Region you wish to provision the cluster in",
+      "min": null,
+      "default": "",
+      "max": null,
+      "required": true,
+      "choices": "us-east-1\neu-west-1\neu-west-2",
+      "variable": "oo_sublocation",
+      "question_name": "AWS Region",
+      "type": "multiplechoice"
+    },
+    {
+      "question_description": "Flag for provisioning logging stack",
+      "min": null,
+      "default": "",
+      "max": null,
+      "required": true,
+      "choices": "true\nfalse",
+      "new_question": true,
+      "variable": "survey_provision_logging",
+      "question_name": "Provision Logging",
+      "type": "multiplechoice"
+    },
+    {
+      "question_description": "Number of master nodes required",
+      "min": 1,
+      "default": 3,
+      "max": 9,
+      "required": true,
+      "new_question": true,
+      "variable": "openshift_aws_master_group_desired_size",
+      "question_name": "Master Nodes",
+      "type": "integer"
+    },
+    {
+      "question_description": "Number of infra nodes required",
+      "min": 3,
+      "default": 3,
+      "max": 9,
+      "required": true,
+      "new_question": true,
+      "variable": "openshift_aws_infra_group_desired_size",
+      "question_name": "Infra Nodes",
+      "type": "integer"
+    },
+    {
+      "question_description": "Number of compute nodes required",
+      "min": 2,
+      "default": 3,
+      "max": 9,
+      "required": true,
+      "new_question": true,
+      "variable": "openshift_aws_compute_group_desired_size",
+      "question_name": "Compute Nodes",
+      "type": "integer"
+    }   
+  ]
+}

--- a/playbooks/roles/tower/tasks/bootstrap.yml
+++ b/playbooks/roles/tower/tasks/bootstrap.yml
@@ -8,7 +8,7 @@
     state: present
     tower_verify_ssl: '{{ tower_verify_ssl }}'
 
-- name: 'Create the {{ tower_team}} team'
+- name: 'Create the {{ tower_team }} team'
   tower_team:
     name: '{{ tower_team }}'
     organization: '{{ tower_organization }}'


### PR DESCRIPTION
**Summary**
The cluster provisioning process allows the required number of node counts (Master, Infra and Compute) to be specified via the survey, with default min and max values applying for each node type.

**Validation** 
1. Login to the following tower instance using the default Tower credentials: https://ansible-tower-web-svc-tower.apps.robrien-5daf.openshiftworkshop.com

2. Run the Provision Cluster job, specifying the number of Master, Infra and Compute nodes required in the survey.

3. Once the job has completed, validate the the number of nodes created match the number specified in the survey. This can be done by logging into the Openshift cluster or the AWS account.

4. Once verified, tear down the cluster using the Cluster Deprovision playbook.

