### PR TITLE
Integreatly workflow survey update

### DIFF
--- a/playbooks/roles/integreatly/templates/workflow_install_survey.json.j2
+++ b/playbooks/roles/integreatly/templates/workflow_install_survey.json.j2
@@ -107,6 +107,28 @@
         "variable": "integreatly_inventory_source_aws_credentials",
         "question_name": "AWS Credentials",
         "type": "multiplechoice"
-      }
-    ]
-  }
+      },
+      {
+       "question_description": "Launcher Github Client ID",
+       "min": null,
+       "default": "",
+       "max": null,
+       "required": false,
+       "new_question": true,
+       "variable": "github_client_id",
+       "question_name": "Launcher Client ID",
+       "type": "text"
+     },
+     {
+       "question_description": "Launcher Github Client Secret",
+       "min": null,
+       "default": "",
+       "max": null,
+       "required": false,
+       "new_question": true,
+       "variable": "github_client_secret",
+       "question_name": "Launcher Client Secret",
+       "type": "text"
+     }
+   ]
+ }


### PR DESCRIPTION
**Summary**
The Integreatly install workflow survey was updated to include the following 2 variables:

1. Launcher GitHub Client ID
2. Launcher GitHub Client Secret

**Validation**
1. Bootstrap an Ansible tower install with all of the resources required to execute an Integreatly install, as per the README:

```
ansible-playbook -i inventories/hosts playbooks/bootstrap_integreatly.yml
```
2. Complete a new Integreatly install using the Integreatly Install Workflow via Ansible Tower, passing in both a valid Launcher GitHub client ID and secret via the survey. Once complete, verify that GitHub verification for Launcher is enabled.
