### PR TITLE
ensure 3scale bucket gets deleted during cluster teardown

### DIFF
--- a/playbooks/roles/cluster/tasks/cluster_teardown.yml
+++ b/playbooks/roles/cluster/tasks/cluster_teardown.yml
@@ -172,6 +172,13 @@
   loop_control:
     label: "{{ item.id }}"
   when: aws_volumes.volumes is defined
+
+- name: Delete 3Scale bucket for {{ aws_cluster_name }}
+  aws_s3:
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    bucket: "{{ aws_cluster_name }}-3scale"
+    mode: delete
   
 - name: Get VPCs for {{ aws_cluster_name }}
   ec2_vpc_net_facts:
@@ -208,4 +215,3 @@
     name: "{{ aws_cluster_name }}"
     region: "{{ aws_region }}"
     state: absent
-


### PR DESCRIPTION
## What
Add task to delete the s3 bucket created for 3scale during cluster provision. This should delete `<cluster-name>-3scale` bucket from AWS.