### PR TITLE
Set tower env var

### DIFF
--- a/playbooks/roles/cluster/tasks/bootstrap_cluster_teardown.yml
+++ b/playbooks/roles/cluster/tasks/bootstrap_cluster_teardown.yml
@@ -81,7 +81,7 @@
     dest: "/tmp/cluster_teardown_workflow_survey.json"
 
 - name: "Update {{ cluster_workflow_teardown_name }} workflow with survey"
-  shell: "tower-cli workflow modify --name=\"{{ cluster_workflow_teardown_name }}\" --survey-enabled=true --survey-spec='@/tmp/cluster_teardown_workflow_survey.json'"
+  shell: "tower-cli workflow modify --name=\"{{ cluster_workflow_teardown_name }}\" --survey-enabled=true --survey-spec='@/tmp/cluster_teardown_workflow_survey.json' --extra-vars='@{{ tower_extra_vars_file_path }}'"
 
 - name: Create {{ cluster_workflow_teardown_name }} workflow schema
   template:

--- a/playbooks/roles/cluster/tasks/bootstrap_cluster_teardown.yml
+++ b/playbooks/roles/cluster/tasks/bootstrap_cluster_teardown.yml
@@ -8,6 +8,7 @@
     project: "{{ cluster_job_template_teardown_project }}"
     state: present
     inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_teardown_out
   until: cluster_create_teardown_out is succeeded
   retries: 10
@@ -23,6 +24,7 @@
     state: present
     inventory: "{{ tower_inventory_name }}"
     vault_credential: "{{ tower_credential_bundle_vault_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_teardown_out
   until: cluster_create_teardown_out is succeeded
   retries: 10
@@ -37,6 +39,7 @@
     project: "{{ cluster_job_template_teardown_project }}"
     state: present
     inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   register: cluster_create_teardown_out
   until: cluster_create_teardown_out is succeeded
   retries: 10
@@ -49,6 +52,7 @@
     description: "{{ cluster_workflow_teardown_desc }}"
     state: present
     organization: "{{ tower_organization }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   
 - name: Retrieve AWS Credential Type ID
   shell: "tower-cli credential_type list --kind cloud -n \"Amazon Web Services\" -f id"

--- a/playbooks/roles/cluster/tasks/workflow.yml
+++ b/playbooks/roles/cluster/tasks/workflow.yml
@@ -159,7 +159,7 @@
     cluster_install_survey_aws_accounts: "{{ cluster_aws_accounts | join('\\n')}}"
 
 - name: "Update Workflow job template with survey"
-  shell: "tower-cli workflow modify --name=\"{{ cluster_workflow_job_template_name }}\" --survey-enabled=true --survey-spec='@{{ role_path }}/templates/workflow_survey.json'"
+  shell: "tower-cli workflow modify --name=\"{{ cluster_workflow_job_template_name }}\" --survey-enabled=true --survey-spec='@{{ role_path }}/templates/workflow_survey.json' --extra-vars='@{{ tower_extra_vars_file_path }}'"
 
 - name: "Update Workflow job template with schema"
   shell: "tower-cli workflow schema \"{{ cluster_workflow_job_template_name }}\" @cluster_workflow_schema.yml"

--- a/playbooks/roles/integreatly/tasks/workflow_install.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_install.yml
@@ -64,7 +64,7 @@
     dest: "/tmp/workflow_install_survey.json"
 
 - name: Update install workflow job template with survey
-  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_install_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_install_survey.json'"
+  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_install_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_install_survey.json' --extra-vars='@{{ tower_extra_vars_file_path }}'"
 
 - name: Update install workflow job template with schema
   shell: "tower-cli workflow schema \"{{ integreatly_workflow_install_job_template_name }}\" @/tmp/workflow_install_schema.yml"

--- a/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
@@ -55,7 +55,7 @@
     dest: "/tmp/workflow_uninstall_survey.json"
 
 - name: Update uninstall workflow job template with survey
-  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_uninstall_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_uninstall_survey.json'"
+  shell: "tower-cli workflow modify --name=\"{{ integreatly_workflow_uninstall_job_template_name }}\" --survey-enabled=true --survey-spec='@/tmp/workflow_uninstall_survey.json' --extra-vars='@{{ tower_extra_vars_file_path }}'"
 
 - name: Update uninstall workflow job template with schema
   shell: "tower-cli workflow schema \"{{ integreatly_workflow_uninstall_job_template_name }}\" @/tmp/workflow_uninstall_schema.yml"

--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -7,6 +7,7 @@ tower_host: '{{ lookup("vars", "_".join((tower_environment, "tower_host")) ) }}'
 tower_username: '{{ lookup("vars", "_".join((tower_environment, "tower_username")) ) }}'
 tower_password: '{{ lookup("vars", "_".join((tower_environment, "tower_password")) ) }}'
 tower_verify_ssl: '{{ lookup("vars", "_".join((tower_environment, "tower_verify_ssl")) ) }}'
+tower_extra_vars_file_path: '/tmp/tower_extra_vars.yml'
 
 # Ansible Tower Openshift Configurations
 tower_openshift_username: ''

--- a/playbooks/roles/tower/tasks/bootstrap.yml
+++ b/playbooks/roles/tower/tasks/bootstrap.yml
@@ -25,6 +25,10 @@
     - 'tower-cli setting modify SOCIAL_AUTH_GITHUB_ORG_ORGANIZATION_MAP "{{ social_auth_github_org_organization_map }}"'
     - 'tower-cli setting modify SOCIAL_AUTH_GITHUB_ORG_TEAM_MAP "{{ social_auth_github_org_team_map }}"'
 
+- name: 'Generate generic tower extra vars file'
+  template:
+    src: 'tower_extra_vars.yml.j2'
+    dest: "{{ tower_extra_vars_file_path }}"
 
 # Import the credentials bootstrap task
 - include_tasks: bootstrap_credentials.yml

--- a/playbooks/roles/tower/tasks/bootstrap_jobs.yml
+++ b/playbooks/roles/tower/tasks/bootstrap_jobs.yml
@@ -11,6 +11,7 @@
     state: present
     inventory: '{{ tower_inventory_name }}'
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    extra_vars_path: '{{ tower_extra_vars_file_path }}'
   register: tower_job_template_authenticate_tower_raw
   until: tower_job_template_authenticate_tower_raw is succeeded
   retries: 10

--- a/playbooks/roles/tower/templates/tower_extra_vars.yml.j2
+++ b/playbooks/roles/tower/templates/tower_extra_vars.yml.j2
@@ -1,0 +1,2 @@
+---
+tower_environment: "{{ tower_environment }}"


### PR DESCRIPTION
**Summary**
At the moment a bootstrap run will break existing or new workflow jobs due to the `tower_environment` var not being set as an extra var. The purpose of this PR is to set the `tower_environment` var as part of the bootstrapping process

**Validation**
Bootstrap a tower instance with cred repo:
```bash
ansible-playbook -i ../<cred-repo>/inventories/hosts playbooks/bootstrap.yml -e tower_environment=<env> --ask-vault-pass
```
The result should be an extra var set on the cluster provision/deprovision workflows, integreatly install/uninstall workflows and the tower auth job template:
```yaml
---
tower_environment: <env>
```