### PR TITLE
add task to update workflow to enable ask_variables_on_launch

### DIFF
--- a/playbooks/roles/cluster/tasks/bootstrap_cluster_teardown.yml
+++ b/playbooks/roles/cluster/tasks/bootstrap_cluster_teardown.yml
@@ -53,6 +53,7 @@
     state: present
     organization: "{{ tower_organization }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: create_workflow_response
   
 - name: Retrieve AWS Credential Type ID
   shell: "tower-cli credential_type list --kind cloud -n \"Amazon Web Services\" -f id"
@@ -90,3 +91,10 @@
 
 - name: "Update {{ cluster_workflow_teardown_name }} workflow job template with schema"
   shell: "tower-cli workflow schema \"{{ cluster_workflow_teardown_name }}\" @/tmp/cluster_teardown_workflow_schema.yml"
+
+# Update the workflow to enable ask_variables_on_launch via the tower api
+- include_role:
+    name: tower
+    tasks_from: enable_ask_variables_on_launch.yml
+  vars:
+    workflow_id: "{{ create_workflow_response.id }}"

--- a/playbooks/roles/cluster/tasks/workflow.yml
+++ b/playbooks/roles/cluster/tasks/workflow.yml
@@ -113,6 +113,7 @@
     state: present
     organization: "{{ tower_organization }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: create_workflow_response
 
 - name: Create workflow schema
   template:
@@ -145,6 +146,13 @@
 
 - name: "Update Workflow job template with schema"
   shell: "tower-cli workflow schema \"{{ cluster_workflow_job_template_name }}\" @cluster_workflow_schema.yml"
+
+# Update the workflow to enable ask_variables_on_launch via the tower api
+- include_role:
+    name: tower
+    tasks_from: enable_ask_variables_on_launch.yml
+  vars:
+    workflow_id: "{{ create_workflow_response.id }}"
 
 - name: Clean up files
   file:

--- a/playbooks/roles/integreatly/tasks/workflow_install.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_install.yml
@@ -52,6 +52,7 @@
     state: present
     organization: "{{ integreatly_workflow_install_job_template_organization }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: create_workflow_response
 
 - name: Create install workflow schema
   template:
@@ -69,6 +70,13 @@
 - name: Update install workflow job template with schema
   shell: "tower-cli workflow schema \"{{ integreatly_workflow_install_job_template_name }}\" @/tmp/workflow_install_schema.yml"
 
+# Update the workflow to enable ask_variables_on_launch via the tower api
+- include_role:
+    name: tower
+    tasks_from: enable_ask_variables_on_launch.yml
+  vars:
+    workflow_id: "{{ create_workflow_response.id }}"
+    
 - name: Cleanup temp install workflow files
   file:
     path: "{{ item }}"

--- a/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
@@ -43,6 +43,7 @@
     state: present
     organization: "{{ integreatly_workflow_uninstall_job_template_organization }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: create_workflow_response
 
 - name: Create uninstall workflow schema
   template:
@@ -59,6 +60,13 @@
 
 - name: Update uninstall workflow job template with schema
   shell: "tower-cli workflow schema \"{{ integreatly_workflow_uninstall_job_template_name }}\" @/tmp/workflow_uninstall_schema.yml"
+
+# Update the workflow to enable ask_variables_on_launch via the tower api
+- include_role:
+    name: tower
+    tasks_from: enable_ask_variables_on_launch.yml
+  vars:
+    workflow_id: "{{ create_workflow_response.id }}"
 
 - name: Cleanup temp uninstall workflow files
   file:

--- a/playbooks/roles/tower/tasks/enable_ask_variables_on_launch.yml
+++ b/playbooks/roles/tower/tasks/enable_ask_variables_on_launch.yml
@@ -1,0 +1,27 @@
+- name: Get workflow job template details for workflow {{ workflow_id }}
+  uri:
+    url: "https://{{ tower_host }}/api/v2/workflow_job_templates/{{ workflow_id }}/"
+    method: "GET"
+    user: "{{ tower_username }}"
+    password: "{{ tower_password }}"
+    force_basic_auth: yes
+    body_format: json
+  register: get_workflow_details_response
+
+- set_fact:
+    workflow: "{{ get_workflow_details_response.json }}"
+
+- name: "Create workflow update template"
+  template:
+    src: "workflow_update.json.j2"
+    dest: "/tmp/workflow_update.json"
+
+- name: Enable ask_variables_on_launch and add for workflow {{ workflow.name }}
+  uri:
+    url: "https://{{ tower_host }}/api/v2/workflow_job_templates/{{ workflow_id }}/"
+    method: "PUT"
+    user: "{{ tower_username }}"
+    password: "{{ tower_password }}"
+    force_basic_auth: yes
+    body_format: json
+    body: "{{ lookup('file', '/tmp/workflow_update.json')}}"

--- a/playbooks/roles/tower/templates/workflow_update.json.j2
+++ b/playbooks/roles/tower/templates/workflow_update.json.j2
@@ -1,0 +1,11 @@
+{
+    "name": "{{ workflow.name }}",
+    "description": "{{ workflow.description }}",
+    "extra_vars": "---\ntower_environment: {{ tower_environment }}",
+    "organization": "{{ workflow.organization }}",
+    "survey_enabled": "{{ workflow.survey_enabled }}",
+    "allow_simultaneous": "{{ workflow.allow_simultaneous}}",
+    "ask_variables_on_launch": true,
+    "inventory": "{{ workflow.inventory }}",
+    "ask_inventory_on_launch": "{{ workflow.ask_inventory_on_launch }}"
+}


### PR DESCRIPTION
## What
Use the Ansible Tower API to update the workflow job templates for `Cluster Provision`, `Integreatly Install`, `Integreatly Uninstall` and `Cluster Teardown` to set the property **ask_variables_on_launch** to true.

**NOTE**: Setting the **ask_variables_on_launch** property to true may be available in the next tower-cli release. PR related to supporting this feature: https://github.com/ansible/tower-cli/pull/691

Reference:
[Ansible Tower API update workflow_job_template documentation](https://docs.ansible.com/ansible-tower/latest/html/towerapi/api_ref.html#/Workflow_Job_Templates/Workflow_Job_Templates_workflow_job_templates_update)

## Verification
1. Bootstrap the workflows mentioned above. The property `ask_variables_on_launch` should be set to true for all those workflows.