### PR TITLE
Update cleandown tasks

### DIFF
--- a/playbooks/cluster_teardown_post_teardown.yml
+++ b/playbooks/cluster_teardown_post_teardown.yml
@@ -2,6 +2,8 @@
 - hosts: localhost
   gather_facts: no
   tasks:
+    - include_vars:
+        ./roles/tower/defaults/main.yml
     - include_role:
         name: cluster
         tasks_from: cluster_teardown_post_teardown.yml

--- a/playbooks/roles/cluster/tasks/cluster_teardown_post_teardown.yml
+++ b/playbooks/roles/cluster/tasks/cluster_teardown_post_teardown.yml
@@ -1,11 +1,12 @@
 - name: "Disassociate {{ cluster_credential_bundle_aws_name }} credentials from {{ cluster_job_template_teardown_name }}"
-  shell: tower-cli job_template disassociate_credential --job-template "{{ cluster_job_template_teardown_name }}" --credential "{{ cluster_credential_bundle_aws_name }}"
+  shell: tower-cli job_template disassociate_credential --job-template "{{ cluster_job_template_teardown_name }}" --credential "{{ cluster_credential_bundle_aws_name }}" --insecure
 
 - name: Delete Ansible Tower Inventory for {{ aws_cluster_name }}
   tower_inventory:
     name: "{{ item }}"
     organization: "secret"
     state: absent
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
   with_items:
     - "{{ aws_cluster_name }}"
     - "{{ aws_cluster_name }}_provisioning_vars"


### PR DESCRIPTION
**Summary**
The cleandown post install task fails on tower instances that use self signed certificates. The purpose of this PR is to add some fixes to support these tower instances.

**Validation**
Run a cluster deprovision job from a tower instance that uses self signed certificates e.g. RHPDS