### PR TITLE
Add integreatly_operator and amq_streams params

### DIFF
--- a/playbooks/roles/integreatly/templates/extra_vars_poc_install.yml.j2
+++ b/playbooks/roles/integreatly/templates/extra_vars_poc_install.yml.j2
@@ -5,6 +5,8 @@ prerequisites_install: false
 create_cluster_admin: false
 backup_restore_install: false
 gitea: false
+integreatly_operator: false
+amq_streams: false
 ns_prefix: 'openshift-'
 run_master_tasks: true
 

--- a/playbooks/roles/integreatly/templates/extra_vars_poc_uninstall.yml.j2
+++ b/playbooks/roles/integreatly/templates/extra_vars_poc_uninstall.yml.j2
@@ -5,5 +5,7 @@ prerequisites_install: false
 create_cluster_admin: false
 backup_restore_install: false
 gitea: false
+integreatly_operator: false
+amq_streams: false
 ns_prefix: 'openshift-'
 run_master_tasks: true


### PR DESCRIPTION
We are adding new parameters to the installer. Values added in this PR will ensure the desired behavior during POC installation - Integreatly operator and AMQ Streams shouldn't be installed.

JIRA: https://issues.jboss.org/browse/INTLY-1554