### PR TITLE
add params for backups s3 bucket secret

### DIFF
--- a/playbooks/roles/integreatly/files/osd_install_survey.json
+++ b/playbooks/roles/integreatly/files/osd_install_survey.json
@@ -124,6 +124,39 @@
         "variable": "threescale_s3_bucket_region",
         "question_name": "3scale S3 bucket region",
         "type": "text"
+      },
+      {
+        "question_description": "AWS access key for backups s3 bucket access",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "variable": "backup_s3_access_key",
+        "question_name": "Backups AWS access key",
+        "type": "text"
+      },
+      {
+        "question_description": "AWS secret key for backups s3 bucket access",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "variable": "backup_s3_secret_key",
+        "question_name": "Backups AWS secret key",
+        "type": "password"
+      },
+      {
+        "question_description": "Backups S3 bucket name",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "variable": "backup_s3_bucket_name",
+        "question_name": "Backups S3 bucket name",
+        "type": "text"
       }
     ]
   }

--- a/playbooks/roles/integreatly/files/osd_install_vars.yml
+++ b/playbooks/roles/integreatly/files/osd_install_vars.yml
@@ -6,15 +6,18 @@ github_client_id: "{{ github_client_id }}"
 github_client_secret: "{{ github_client_secret }}"
 openshift_token: "{{ openshift_token }}"
 rhsso_evals_admin_password: "{{ rhsso_admin_pass }}"
-threescale_storage_s3_aws_access_key: "{{ threescale_s3_access_key}}"
+threescale_storage_s3_aws_access_key: "{{ threescale_s3_access_key }}"
 threescale_storage_s3_aws_secret_key: "{{ threescale_s3_secret_key }}"
 threescale_storage_s3_aws_bucket: "{{ threescale_s3_bucket_name }}"
 threescale_storage_s3_aws_region: "{{ threescale_s3_bucket_region }}"
 
-
+backup_restore_install: true
+backup_s3_aws_access_key: "{{ backup_s3_access_key }}"
+backup_s3_aws_secret_key: "{{ backup_s3_secret_key }}"
+backup_s3_aws_bucket: "{{ backup_s3_bucket_name }}"
 aws_s3_backup_secret_name: s3-credentials
 aws_s3_backup_secret_namespace: openshift-integreatly-backups
-backup_restore_install: true
+
 create_cluster_admin: false
 eval_seed_users_count: 0
 eval_self_signed_certs: false
@@ -26,3 +29,4 @@ run_master_tasks: false
 threescale_file_upload_storage: s3
 integreatly_operator: false 
 amq_streams: false
+


### PR DESCRIPTION
Once complete, we can remove the workaround where the namespace and secret have to be created manually before install.