### PR TITLE
ensure inventory is synced

### DIFF
--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -126,3 +126,4 @@ integreatly_osd_install_name: "Integreatly_Install_Template_[OSD]"
 integreatly_osd_bootstrap_name: "Integreatly_Bootstrap_Template_[OSD]"
 integreatly_osd_workflow_name: "Integreatly_Bootstrap_and_Install_[OSD]"
 integreatly_osd_workflow_description: "Workflow to configure and install integreatly on an OSD cluster"
+integreatly_osd_source_project_update_on_launch: true

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_install.yml
@@ -13,6 +13,17 @@
     scm_delete_on_update: "{{ integreatly_project_install_scm_delete_on_update }}"
     scm_credential: "{{ integreatly_credential_bundle_github_name }}"
     tower_verify_ssl: "{{ tower_verify_ssl }}"
+  register: integreatly_install_out
+  until: integreatly_install_out is succeeded
+  retries: 10
+  delay: 5
+
+- name: Wait for project to be successfully synced to tower
+  shell: tower-cli project status {{ integreatly_install_out.id }} 
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: Create OSD inventory in tower
   tower_inventory:
@@ -30,18 +41,15 @@
     description: "From Project: integreatly-install-release-{{ integreatly_osd_install_branch }}"
     overwrite: "{{ integreatly_inventory_source_project_overwrite }}"
     overwrite_vars: "{{ integreatly_inventory_source_project_overwrite_vars }}"
-    update_on_launch: "{{ integreatly_inventory_source_project_update_on_launch }}"
+    update_on_launch: "{{ integreatly_osd_source_project_update_on_launch }}"
     source_project: "integreatly-install-{{ integreatly_osd_install_branch }}"
     source_path: "{{ integreatly_osd_install_source_path }}"
     state: present
     tower_verify_ssl: "{{ tower_verify_ssl }}"
-  register: integreatly_install_out
-  until: integreatly_install_out is succeeded
+  register: integreatly_source_out
+  until: integreatly_source_out is succeeded
   retries: 10
   delay: 5
-
-- name: Sync inventory source
-  shell: "tower-cli inventory_source update {{ integreatly_osd_install_source_name }}"
 
 - name: Create OSD Integreatly bootstrap job template
   tower_job_template:


### PR DESCRIPTION
Sourcing the inventory through tower-cli seems to be causing problems. The source would fail with `cannot find cwd`.

Setting the inventory to sync itself on each run seems like a simpler and more robust way to handle it.

*To Validate*
1. A tower with all necessary resources bootstrapped
2. Run the OSD bootstrap and install job pointing to a real branch/tag of installation repo but enter anything ( test ) for the rest of the survey question
3. See that the inventory successfully syncs on launch of the integreatly install step of the workflow