### PR TITLE
Renaming cluster_type variable

### DIFF
--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -2,14 +2,14 @@
 
 # Cluster Configurations
 cluster_name: ''
-cluster_type: 'poc' # (poc|rhpds|dev)
 cluster_provisioning_vars_inventory: "{{ cluster_name }}"
 cluster_aws_region: ''
 cluster_aws_access_key: ''
 cluster_aws_secret_access_key: ''
 
-# Integreatly
+# Integreatly Configurations
 integreatly_version: 'release-1.4.0'
+integreatly_install_type: 'poc'
 
 # Workflow Job Template
 integreatly_workflow_install_job_template_name: 'Integreatly Install Workflow'

--- a/playbooks/roles/integreatly/tasks/bootstrap_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_install.yml
@@ -131,12 +131,12 @@
 
 - name: Generate extra vars file
   template:
-    dest: "/tmp/extra_vars_{{ cluster_type }}_install.yml"
-    src: "extra_vars_{{ cluster_type }}_install.yml.j2"
+    dest: "/tmp/extra_vars_{{ integreatly_install_type }}_install.yml"
+    src: "extra_vars_{{ integreatly_install_type }}_install.yml.j2"
 
 - name: "Update workflow stage {{ integreatly_job_template_deploy_name }}"
-  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_deploy_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_install_name }} --playbook {{ integreatly_job_template_deploy_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@/tmp/extra_vars_{{ cluster_type }}_install.yml'"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_deploy_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_install_name }} --playbook {{ integreatly_job_template_deploy_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@/tmp/extra_vars_{{ integreatly_install_type }}_install.yml'"
 
 - name: Cleanup temp var file
   file:
-    path: "/tmp/extra_vars_{{ cluster_type }}_install.yml"
+    path: "/tmp/extra_vars_{{ integreatly_install_type }}_install.yml"

--- a/playbooks/roles/integreatly/tasks/bootstrap_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_uninstall.yml
@@ -17,11 +17,11 @@
 
 - name: Generate extra vars file
   template:
-    dest: "/tmp/extra_vars_{{ cluster_type }}_uninstall.yml"
-    src: "extra_vars_{{ cluster_type }}_uninstall.yml.j2"
+    dest: "/tmp/extra_vars_{{ integreatly_install_type }}_uninstall.yml"
+    src: "extra_vars_{{ integreatly_install_type }}_uninstall.yml.j2"
 
 - name: "Update workflow stage {{ integreatly_job_template_uninstall_name }}"
-  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_uninstall_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_uninstall_name }} --playbook {{ integreatly_job_template_uninstall_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@/tmp/extra_vars_{{ cluster_type }}_uninstall.yml'"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_uninstall_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_uninstall_name }} --playbook {{ integreatly_job_template_uninstall_playbook }} --credential {{ tower_credential_bundle_default_name }} --extra-vars '@/tmp/extra_vars_{{ integreatly_install_type }}_uninstall.yml'"
   register: uninstall_workflow_update
   retries: 10
   delay: 3


### PR DESCRIPTION
**Summary**
Having two separate `cluster_type` variables for both cluster provisions and integreatly installs on tower is leading to some conflicts. The purpose of this change is to rename the integreatly `cluster_type` variable to `integreatly_install_type`

**Validation**
- Execute an Integreatly install against a Tower provisioned cluster