### PR TITLE
Expose cluster details

### DIFF
--- a/playbooks/cluster_create_post_install.yml
+++ b/playbooks/cluster_create_post_install.yml
@@ -72,3 +72,15 @@
   - name: Create secret for backups
     shell: "oc create secret generic {{ cluster_backup_secret_name }} --from-literal=aws_access_key={{ hostvars['localhost']['iam_access_key'] }} --from-literal=aws_secret_key={{ hostvars['localhost']['iam_secret_key'] }} --from-literal=bucket_name={{ cluster_backup_bucket_name }} -n {{ cluster_backup_namespace }}"
     no_log: true
+  
+  - name: Retrieving IP addresses of master nodes
+    shell: "oc get nodes -o wide | grep master | awk '{ print $7 }'"
+    register: master_node_ip_addresses
+
+  - name: Cluster Details
+    debug:
+      msg: "{{ item }}"
+    with_items:
+    - "Console URL: {{ openshift_master_public_console_url }}"
+    - "Admin username: {{ openshift_master_htpasswd_users.keys() }}"
+    - "Master node IP addresses: {{ master_node_ip_addresses.stdout_lines }}"


### PR DESCRIPTION
**Summary**
Newly created clusters did not expose any of the following details once provisioned:

- `cluster URL`
- `cluster-admin username`
- `external IP of the master nodes`

The cluster create post install job was updated to include the above details.

**Prerequitresites**

- A tower instance bootstapped as such that a successful cluster create job can be completed

**Verification Steps**

- The `Ansible Tower Configuration Project` on your tower instance must be updated to point to the correct project (`https://github.com/obrienrobert/ansible-tower-configuration`) and branch (`expose_cluster_details`)
- Run a cluster create job, using the Provision Cluster job template
- When complete, ensure the the Post install logs include the following 3 tasks, with each task displaying the correct variables.

- `Cluster console URL`: URL to the cluster console
- `Cluster admin username`: admin username
- `IP addresses of master nodes`: Master node External IP addresses (`oc get nodes -o wide | grep master`)

**Verification Completion**
Verification can be deemed complete once the above steps run without error, and the post install step on the workflow displays the correct variables.