### PR TITLE
Integreatly installation encrypted vars

### DIFF
--- a/playbooks/roles/integreatly/tasks/workflow_install.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_install.yml
@@ -22,6 +22,7 @@
     credential: "{{ integreatly_job_template_deploy_credentials }}"
     state: present
     inventory: "{{ tower_inventory_name }}"
+    vault_credential: "{{ tower_credential_bundle_vault_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: Retrieve AWS Credential Type ID

--- a/playbooks/roles/integreatly/templates/extra_vars_poc_install.yml.j2
+++ b/playbooks/roles/integreatly/templates/extra_vars_poc_install.yml.j2
@@ -12,7 +12,7 @@ run_master_tasks: true
 
 # 3scale
 threescale_file_upload_storage: s3
-threescale_storage_s3_aws_access_key: "{{ cluster_aws_access_key }}"
-threescale_storage_s3_aws_secret_key: "{{ cluster_aws_secret_access_key }}"
+threescale_storage_s3_aws_access_key: "{%raw%}{{ AWS_ACCESS_KEY_ID }}{%endraw%}"
+threescale_storage_s3_aws_secret_key: "{%raw%}{{ AWS_SECRET_ACCESS_KEY }}{%endraw%}"
 threescale_storage_s3_aws_region: "{{ cluster_aws_region }}"
 threescale_storage_s3_aws_bucket: "{{ cluster_name }}-3scale"


### PR DESCRIPTION
### Summary
All plain text passwords/credentials stored within inventory files  and `integreatly deploy` job template within tower are required to be vault encrypted.

### Prerequisites

- A tower instance to test against
- Access to https://github.com/fheng/integreatly_dev

### Linked PR's

https://github.com/integr8ly/tower_dummy_credentials/pull/5
https://github.com/fheng/integreatly_dev/pull/22

### Verification Steps

-  Bootstrap tower using this feature branch, as per: https://github.com/integr8ly/ansible-tower-configuration#41-tower-bootstrapping. 
- Update your inventory file to include your tower details
-  Ensure job isolation is disabled
- Update the projects to point to the correct repositories/feature branches, as specified below:

    **Ansible tower configuration project**:
   `https://github.com/obrienrobert/ansible-tower-configuration.git`: `integreatly_encrypted_vars`

   **Ansible tower credentials project**:
   `git@github.com:fheng/integreatly_dev.git`: `provisioning_vars_template_update`

- Run a cluster create and once complete, an integreatly install.

- Verify that both a cluster create and integreatly install successfully complete, and that the following generated inventories contain vault encrypted variables: 

1. `Provisioning_inventory`
2. `<cluster name>`

Also verify that the extra-variables in the `Integreatly Deploy Template` contains encrypted AWS access and secret keys.