### PR TITLE
OSD Integreatly uninstall job

### DIFF
--- a/playbooks/bootstrap_osd_integreatly_install.yml
+++ b/playbooks/bootstrap_osd_integreatly_install.yml
@@ -10,3 +10,7 @@
     - include_role:
         name: integreatly
         tasks_from: bootstrap_osd_update_workflow.yml
+    - include_role:
+        name: integreatly
+        tasks_from: bootstrap_osd_uninstall_workflow.yml
+    

--- a/playbooks/osd_integreatly_uninstall.yml
+++ b/playbooks/osd_integreatly_uninstall.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_vars:
+        ./roles/tower/defaults/main.yml
+    - include_role:
+        name: integreatly
+        tasks_from: bootstrap_osd_uninstall.yml

--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -122,7 +122,7 @@ integreatly_osd_install_branch: 'release-1.4.0'
 integreatly_osd_project_install_scm_url: "git@github.com:integr8ly/installation.git"
 integreatly_osd_install_desc: "Integreatly Project: {{ integreatly_osd_install_branch }}"
 integreatly_osd_install_org: integreatly
-integreatly_osd_install_inventory: OSD_Tower_Inventory
+integreatly_osd_install_inventory: OSD_Tower_Install_Inventory
 integreatly_osd_install_source_name:  installation-project-source
 integreatly_osd_install_source_path: "inventories/"
 integreatly_osd_install_name: "Integreatly_Install_Template_[OSD]"
@@ -131,7 +131,21 @@ integreatly_osd_workflow_name: "Integreatly_Bootstrap_and_Install_[OSD]"
 integreatly_osd_workflow_description: "Workflow to configure and install integreatly on an OSD cluster"
 integreatly_osd_source_project_update_on_launch: true
 
+# OSD uninstall
+integreatly_osd_uninstall_branch: 'release-1.4.0'
+integreatly_osd_project_uninstall_scm_url: "git@github.com:integr8ly/installation.git"
+integreatly_osd_uninstall_desc: "Integreatly Project: {{ integreatly_osd_uninstall_branch }}"
+integreatly_osd_uninstall_org: integreatly
+integreatly_osd_uninstall_inventory: OSD_Tower_Uninstall_Inventory
+integreatly_osd_uninstall_source_name:  uninstall-project-source
+integreatly_osd_uninstall_source_path: "inventories/"
+integreatly_osd_uninstall_name: "Integreatly_Uninstall_Template_[OSD]"
+integreatly_osd_uninstall_bootstrap_name: "Integreatly_Bootstrap_Uninstall_Template_[OSD]"
+integreatly_osd_uninstall_workflow_name: "Integreatly_Bootstrap_and_Uninstall_[OSD]"
+integreatly_osd_uninstall_workflow_description: "Workflow to uninstall integreatly from an OSD cluster"
+integreatly_osd_uninstall_source_project_update_on_launch: true
 
+# OSD upgrade
 integreatly_osd_upgrade_bootstrap_name: "Integreatly_Upgrade_Bootstrap_Template_[OSD]"
 integreatly_osd_upgrade_source_name: update-project-source
 integreatly_osd_upgrade_name: "Integreatly_Upgrade_[OSD]"

--- a/playbooks/roles/integreatly/files/osd_uninstall_survey.json
+++ b/playbooks/roles/integreatly/files/osd_uninstall_survey.json
@@ -1,0 +1,52 @@
+{
+  "description": "",
+  "name": "",
+  "spec": [
+    {
+      "question_description": "Name of target cluster to run Integreatly uninstall against",
+      "min": 0,
+      "default": "",
+      "max": 20,
+      "required": true,
+      "choices": "",
+      "variable": "cluster_name",
+      "question_name": "Cluster Name",
+      "type": "text"
+    },
+    {
+      "question_description": "Integreatly Uninstall Git branch/tag",
+      "min": 0,
+      "default": "",
+      "max": 1024,
+      "required": true,
+      "choices": "",
+      "new_question": true,
+      "variable": "integreatly_osd_uninstall_branch",
+      "question_name": "Integreatly uninstall branch",
+      "type": "text"
+    },
+    {
+      "question_description": "Router shard of the targeted cluster",
+      "min": 0,
+      "default": "",
+      "max": 5,
+      "required": true,
+      "choices": "",
+      "variable": "router_shard",
+      "question_name": "Router shard",
+      "type": "text"
+    },
+    {
+      "question_description": "Openshift token for cluster-admin user",
+      "min": 0,
+      "default": "",
+      "max": 1024,
+      "required": true,
+      "choices": "",
+      "new_question": true,
+      "variable": "openshift_token",
+      "question_name": "Openshift token",
+      "type": "password"
+    }
+  ]
+}

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall.yml
@@ -1,0 +1,84 @@
+---
+- name: "Create integreatly uninstall project for {{ integreatly_osd_uninstall_branch }}"
+  tower_project:
+    name: "integreatly-uninstall-{{ integreatly_osd_uninstall_branch }}"
+    description: "{{ integreatly_osd_uninstall_desc }}"
+    organization: "{{ integreatly_osd_uninstall_org }}"
+    state: present
+    scm_type: "{{ integreatly_project_uninstall_scm_type }}"
+    scm_url: "{{ integreatly_osd_project_uninstall_scm_url }}"
+    scm_branch: "{{ integreatly_osd_uninstall_branch }}"
+    scm_clean: "{{ integreatly_project_uninstall_scm_clean }}"
+    scm_update_on_launch: "{{ integreatly_project_uninstall_scm_update_on_launch }}"
+    scm_delete_on_update: "{{ integreatly_project_uninstall_scm_delete_on_update }}"
+    scm_credential: "{{ integreatly_credential_bundle_github_name }}"
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+  register: integreatly_uninstall_out
+  until: integreatly_uninstall_out is succeeded
+  retries: 10
+  delay: 5
+
+- name: Wait for project to be successfully synced to tower
+  shell: tower-cli project status {{ integreatly_uninstall_out.id }} 
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
+
+- name: Create OSD uninstall inventory in tower
+  tower_inventory:
+    name: "{{ integreatly_osd_uninstall_inventory }}"
+    description: "Inventory for OSD Integreatly uninstalls"
+    organization: "{{ integreatly_osd_uninstall_org }}"
+    state: present
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+
+- name: Create inventory source for OSD inventory
+  tower_inventory_source:
+    name: "{{ integreatly_osd_uninstall_source_name }}"
+    inventory: "{{ integreatly_osd_uninstall_inventory }}"
+    source: "{{ integreatly_inventory_source_project_type }}"
+    description: "From Project: integreatly-uninstall-release-{{ integreatly_osd_install_branch }}"
+    overwrite: "{{ integreatly_inventory_source_project_overwrite }}"
+    overwrite_vars: "{{ integreatly_inventory_source_project_overwrite_vars }}"
+    update_on_launch: "{{ integreatly_osd_source_project_update_on_launch }}"
+    source_project: "integreatly-uninstall-{{ integreatly_osd_install_branch }}"
+    source_path: "{{ integreatly_osd_uninstall_source_path }}"
+    state: present
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+  register: integreatly_source_out
+  until: integreatly_source_out is succeeded
+  retries: 10
+  delay: 5
+
+- name: Create OSD Integreatly uninstall bootstrap job template
+  tower_job_template:
+    job_type: run
+    playbook: playbooks/osd_integreatly_uninstall.yml
+    name: "{{ integreatly_osd_uninstall_bootstrap_name }}"
+    project: "{{ tower_configuration_project_name }}"
+    credential: "{{ tower_credential_bundle_default_name }}"
+    description: Job for bootstrapping Integreatly uninstall on Openshift Dedicated
+    state: present 
+    inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+
+- name: Create OSD Integreatly uninstall job template
+  tower_job_template:
+    job_type: run
+    playbook: playbooks/uninstall.yml
+    name: "{{ integreatly_osd_uninstall_name }}"
+    project: "integreatly-uninstall-{{ integreatly_osd_uninstall_branch }}"
+    credential: "{{ tower_credential_bundle_default_name }}"
+    description: Job for uninstalling Integreatly on Openshift Dedicated
+    state: present 
+    extra_vars_path: roles/integreatly/files/osd_install_vars.yml
+    inventory: "{{ integreatly_osd_uninstall_inventory }}"
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+  register: integreatly_deploy_out
+  until: integreatly_deploy_out is succeeded
+  retries: 10
+  delay: 5
+
+- name: "Update workflow stage {{ integreatly_job_template_uninstall_name }}"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_osd_uninstall_name }}\" --project integreatly-uninstall-{{ integreatly_osd_uninstall_branch }} --playbook playbooks/uninstall.yml"

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall_workflow.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall_workflow.yml
@@ -1,0 +1,33 @@
+---
+- include_tasks: bootstrap_osd_uninstall.yml
+
+- name: "Create workflow: {{ integreatly_workflow_uninstall_job_template_name }}"
+  tower_workflow_template:
+    name:  "{{ integreatly_osd_uninstall_workflow_name }}"
+    description: "{{ integreatly_osd_uninstall_workflow_description }}"
+    state: present
+    organization: "{{ integreatly_osd_uninstall_org }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: create_workflow_response
+
+- name: Create uninstall workflow schema
+  template:
+    src: osd_workflow_uninstall_schema.yml.j2
+    dest: "/tmp/osd_workflow_uninstall_schema.yml"
+
+- name: Update uninstall workflow job template with survey
+  shell: "tower-cli workflow modify --name=\"{{ integreatly_osd_uninstall_workflow_name }}\" --survey-enabled=true --survey-spec='@{{ role_path }}/files/osd_uninstall_survey.json'"
+
+- name: Update uninstall workflow job template with schema
+  shell: "tower-cli workflow schema \"{{ integreatly_osd_uninstall_workflow_name }}\" @/tmp/osd_workflow_uninstall_schema.yml"
+
+# Update the workflow to enable ask_variables_on_launch via the tower api
+- include_role:
+    name: tower
+    tasks_from: enable_ask_variables_on_launch.yml
+  vars:
+    workflow_id: "{{ create_workflow_response.id }}"
+    
+- name: Cleanup temp install workflow files
+  file:
+    path: "/tmp/osd_workflow_uninstall_schema.yml"

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_update_workflow.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_update_workflow.yml
@@ -4,7 +4,7 @@
 - name: "Create workflow: {{ integreatly_osd_upgrade_workflow_name }}"
   tower_workflow_template:
     name:  "{{ integreatly_osd_upgrade_workflow_name }}"
-    description: "{{ integreatly_osd_workflow_description }}"
+    description: "{{ integreatly_osd_upgrade_desc }}"
     state: present
     organization: "{{ integreatly_osd_install_org }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'

--- a/playbooks/roles/integreatly/templates/osd_workflow_uninstall_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/osd_workflow_uninstall_schema.yml.j2
@@ -1,0 +1,6 @@
+---
+- job_template: "{{ tower_job_template_authenticate_tower_name }}"
+  success:
+  - job_template: "{{ integreatly_osd_uninstall_bootstrap_name }}"
+    success:
+    - job_template: "{{ integreatly_osd_uninstall_name }}"


### PR DESCRIPTION
## Summary
Bootstraps the required Tower resources to uninstall Integreatly from an OSD cluster.

## Prerequisites
An already bootstrapped tower instance to test on.

## Verification Steps

- Update the Ansible Tower Configuration project on your tower instance so that it points to the correct repository and branch:

  `SCM URL`: `https://github.com/obrienrobert/ansible-tower-configuration.git`
  `SCM Branch`: `osd_integreatly_uninstall`

- Checkout this feature branch
- Bootstrap tower with the required OSD Integreatly uninstall resources:

```
ansible-playbook -i <path_to_credentials_project>/inventories/hosts playbooks/osd_integreatly_uninstall.yml -e tower_environment=<tower_enviroment> --ask-vault-pass
```


- Using the newly created `Integreatly_Bootstrap_and_Uninstall_[OSD]` job template, run an Integreatly uninstall against an OSD cluster.

- Verification can be deemed complete if the uninstall completed successfully and without error.

