### PR TITLE
Adding step to remove master.evals.example.com host

### DIFF
--- a/playbooks/roles/integreatly/tasks/bootstrap_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_install.yml
@@ -126,6 +126,13 @@
   retries: 10
   delay: 5
 
+- name: "Remove master.evals.example.com host reference from inventory"
+  shell: "tower-cli host delete -n master.evals.example.com -i {{ integreatly_inventory_name }}"
+  register: remove_host_ref_raw
+  until: remove_host_ref_raw is succeeded
+  retries: 10
+  delay: 5
+
 - name: Retrieve cluster provisioning vars inventory
   shell: "tower-cli inventory get -n \"{{ cluster_provisioning_vars_inventory }}\" -f json"
   register: cluster_provisioning_vars_raw


### PR DESCRIPTION
**Summary**
Updating Integreatly bootstrap install playbook to support latest host file changes [1] made on the Integreatly installation repository

[1] https://github.com/integr8ly/installation/commit/84a99c6488a784f8e2b08185bb43dc1d02377037