### PR TITLE
Installing oc binary in tower bootstrap image

### DIFF
--- a/images/tower_bootstrap/Dockerfile
+++ b/images/tower_bootstrap/Dockerfile
@@ -1,6 +1,8 @@
 FROM centos:latest
 
-WORKDIR /ansible-tower-configuration 
+WORKDIR /ansible-tower-configuration
+
+ADD https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit.tar.gz /tmp/
 
 # ansible, python-pip and tower-cli installation
 RUN yum -y update && \
@@ -9,4 +11,8 @@ RUN yum -y update && \
     yum install -y python-pip && \
     yum clean all && \
     pip install --upgrade pip && \
-    pip install ansible-tower-cli
+    pip install ansible-tower-cli && \
+    sh -c "tar -xzf /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit.tar.gz -C /tmp/" && \
+    sh -c "mv /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit/oc /usr/bin/oc" && \ 
+    sh -c "rm /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit.tar.gz" && \
+    chmod 755 /usr/bin/oc


### PR DESCRIPTION
**Summary**
This change is to support the install of Tower on Openshift using the `tower_bootstrap` image

**Validation**
Install Tower using the bootstrap image, see example command below:
```
docker run -it -v /Users/pmccarthy/repos/ansible-tower-configuration:/ansible-tower-configuration:Z -v /Users/pmccarthy/repos/integreatly_dev:/integreatly_dev:Z quay.io/integreatly/ansible-tower-bootstrap:test ansible-playbook -i /integreatly_dev/inventories/hosts playbooks/install_tower.yml -e tower_openshift_master_url=<CHANGEME> -e tower_openshift_username=<CHANGEME> -e tower_openshift_password=<CHANGEME>--ask-vault-pass
```