### PR TITLE
Intly job concurrency support

### DIFF
--- a/playbooks/bootstrap_integreatly_install.yml
+++ b/playbooks/bootstrap_integreatly_install.yml
@@ -1,4 +1,6 @@
 ---
+- import_playbook: "./authenticate_tower.yml"
+
 - hosts: localhost
   gather_facts: no
   tasks:

--- a/playbooks/bootstrap_integreatly_uninstall.yml
+++ b/playbooks/bootstrap_integreatly_uninstall.yml
@@ -1,4 +1,6 @@
 ---
+- import_playbook: "./authenticate_tower.yml"
+
 - hosts: localhost
   gather_facts: no
   tasks:

--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -15,10 +15,12 @@ integreatly_install_type: 'poc'
 integreatly_workflow_install_job_template_name: 'Integreatly Install Workflow'
 integreatly_workflow_install_job_template_desc: 'Workflow for Installing Integreatly on Openshift'
 integreatly_workflow_install_job_template_organization: "{{ tower_organization }}"
+integreatly_workflow_install_job_template_concurrency: true
 
 integreatly_workflow_uninstall_job_template_name: 'Integreatly Uninstall Workflow'
 integreatly_workflow_uninstall_job_template_desc: 'Workflow for Uninstalling Integreatly on Openshift'
 integreatly_workflow_uninstall_job_template_organization: "{{ tower_organization }}"
+integreatly_workflow_uninstall_job_template_concurrency: true
 
 # Integreatly Credentials
 integreatly_credential_bundle_github_name: "tower_github_scm"
@@ -31,12 +33,14 @@ integreatly_job_template_bootstrap_install_desc: 'Job for bootstrapping integrea
 integreatly_job_template_bootstrap_install_type: 'run'
 integreatly_job_template_bootstrap_install_playbook: 'playbooks/bootstrap_integreatly_install.yml'
 integreatly_job_template_bootstrap_install_credentials: "{{ tower_credential_bundle_default_name }}"
+integreatly_job_template_bootstrap_install_concurrency: true
 
 integreatly_job_template_deploy_name: 'Integreatly Deploy Template'
 integreatly_job_template_deploy_desc: 'Job for deploying Integreatly on Openshift'
 integreatly_job_template_deploy_type: 'run'
 integreatly_job_template_deploy_playbook: 'playbooks/install.yml'
 integreatly_job_template_deploy_credentials: "{{ tower_credential_bundle_default_name }}"
+integreatly_job_template_deploy_concurrency: true
 
 # Integreatly Job Templates: Uninstall
 integreatly_job_template_uninstall_name: 'Integreatly Uninstall Template'
@@ -44,12 +48,14 @@ integreatly_job_template_uninstall_desc: 'Job for uninstalling Integreatly on Op
 integreatly_job_template_uninstall_type: 'run'
 integreatly_job_template_uninstall_playbook: 'playbooks/uninstall.yml'
 integreatly_job_template_uninstall_credentials: "{{ tower_credential_bundle_default_name }}"
+integreatly_job_template_uninstall_concurrency: true
 
 integreatly_job_template_bootstrap_uninstall_name: 'Integreatly Bootstrap Uninstall Template'
 integreatly_job_template_bootstrap_uninstall_desc: 'Job for bootstrapping resources for Integreatly uninstall'
 integreatly_job_template_bootstrap_uninstall_type: 'run'
 integreatly_job_template_bootstrap_uninstall_playbook: 'playbooks/bootstrap_integreatly_uninstall.yml'
 integreatly_job_template_bootstrap_uninstall_credentials: "{{ tower_credential_bundle_default_name }}"
+integreatly_job_template_bootstrap_uninstall_concurrency: true
 
 integreatly_job_template_cleandown_name: 'Integreatly Clean Down Template'
 integreatly_job_template_cleandown_desc: 'Job for cleaning down Integreatly resources'

--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -70,7 +70,7 @@ integreatly_project_install_desc: "Integreatly Project for Branch: {{ integreatl
 integreatly_project_install_scm_type: git
 integreatly_project_install_scm_clean: true
 integreatly_project_install_scm_url: ''
-integreatly_project_install_scm_update_on_launch: true
+integreatly_project_install_scm_update_on_launch: false
 integreatly_project_install_scm_delete_on_update: true
 
 integreatly_project_uninstall_scm_branch: ''
@@ -79,7 +79,7 @@ integreatly_project_uninstall_desc: "Integreatly Project for Branch: {{ integrea
 integreatly_project_uninstall_scm_type: git
 integreatly_project_uninstall_scm_clean: true
 integreatly_project_uninstall_scm_url: ''
-integreatly_project_uninstall_scm_update_on_launch: true
+integreatly_project_uninstall_scm_update_on_launch: false
 integreatly_project_uninstall_scm_delete_on_update: true
 
 # Integreatly Inventories

--- a/playbooks/roles/integreatly/tasks/bootstrap_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_install.yml
@@ -23,6 +23,13 @@
     scm_credential: "{{ integreatly_credential_bundle_github_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
 
+- name: "Sync project: {{ integreatly_project_install_name }}"
+  shell: "tower-cli project update -n {{ integreatly_project_install_name }}"
+  register: install_project_update
+  retries: 10
+  delay: 3
+  until: install_project_update.rc == 0
+
 - name: "Create inventory source AWS: {{ integreatly_inventory_source_aws_name }}"
   tower_inventory_source:
     name: "{{ integreatly_inventory_source_aws_name }}"

--- a/playbooks/roles/integreatly/tasks/bootstrap_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_uninstall.yml
@@ -15,6 +15,13 @@
     scm_credential: "{{ integreatly_credential_bundle_github_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
 
+- name: "Sync project: {{ integreatly_project_uninstall_name }}"
+  shell: "tower-cli project update -n {{ integreatly_project_uninstall_name }}"
+  register: uninstall_project_update
+  retries: 10
+  delay: 3
+  until: uninstall_project_update.rc == 0
+
 - name: Generate extra vars file
   template:
     dest: "/tmp/extra_vars_{{ integreatly_install_type }}_uninstall.yml"

--- a/playbooks/roles/integreatly/tasks/workflow_install.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_install.yml
@@ -12,6 +12,7 @@
     inventory: "{{ tower_inventory_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
     extra_vars_path: '{{ tower_extra_vars_file_path }}'
+    concurrent_jobs_enabled: '{{ integreatly_job_template_bootstrap_install_concurrency }}'
 
 - name: "Configure Integreatly Deploy job template: {{ integreatly_job_template_deploy_name }}"
   tower_job_template:
@@ -25,6 +26,7 @@
     inventory: "{{ tower_inventory_name }}"
     vault_credential: "{{ tower_credential_bundle_vault_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    concurrent_jobs_enabled: '{{ integreatly_job_template_deploy_concurrency }}'
 
 - name: Retrieve AWS Credential Type ID
   shell: "tower-cli credential_type list --kind cloud -n \"Amazon Web Services\" -f id"
@@ -54,6 +56,7 @@
     state: present
     organization: "{{ integreatly_workflow_install_job_template_organization }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    allow_simultaneous: '{{ integreatly_workflow_install_job_template_concurrency }}'
   register: create_workflow_response
 
 - name: Create install workflow schema

--- a/playbooks/roles/integreatly/tasks/workflow_install.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_install.yml
@@ -11,6 +11,7 @@
     state: present
     inventory: "{{ tower_inventory_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    extra_vars_path: '{{ tower_extra_vars_file_path }}'
 
 - name: "Configure Integreatly Deploy job template: {{ integreatly_job_template_deploy_name }}"
   tower_job_template:

--- a/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
@@ -23,6 +23,7 @@
     state: present
     inventory: "{{ tower_inventory_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    extra_vars_path: '{{ tower_extra_vars_file_path }}'
 
 - name: "Configure Cluster Clean Down template: {{ integreatly_job_template_cleandown_name }}"
   tower_job_template:

--- a/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/workflow_uninstall.yml
@@ -11,6 +11,7 @@
     state: present
     inventory: "{{ tower_inventory_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    concurrent_jobs_enabled: '{{ integreatly_job_template_uninstall_concurrency }}'
 
 - name: "Configure Integreatly Bootstrap Uninstall job template: {{ integreatly_job_template_bootstrap_uninstall_name }}"
   tower_job_template:
@@ -24,6 +25,7 @@
     inventory: "{{ tower_inventory_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
     extra_vars_path: '{{ tower_extra_vars_file_path }}'
+    concurrent_jobs_enabled: '{{ integreatly_job_template_bootstrap_uninstall_concurrency }}'
 
 - name: "Configure Cluster Clean Down template: {{ integreatly_job_template_cleandown_name }}"
   tower_job_template:
@@ -44,6 +46,7 @@
     state: present
     organization: "{{ integreatly_workflow_uninstall_job_template_organization }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    allow_simultaneous: '{{ integreatly_workflow_uninstall_job_template_concurrency }}'
   register: create_workflow_response
 
 - name: Create uninstall workflow schema

--- a/playbooks/roles/integreatly/templates/workflow_install_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/workflow_install_schema.yml.j2
@@ -1,6 +1,4 @@
 ---
-- job_template: "{{ tower_job_template_authenticate_tower_name }}"
+- job_template: "{{ integreatly_job_template_bootstrap_install_name }}"
   success:
-  - job_template: "{{ integreatly_job_template_bootstrap_install_name }}"
-    success:
-    - job_template: "{{ integreatly_job_template_deploy_name }}"
+  - job_template: "{{ integreatly_job_template_deploy_name }}"

--- a/playbooks/roles/integreatly/templates/workflow_uninstall_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/workflow_uninstall_schema.yml.j2
@@ -1,6 +1,4 @@
 ---
-- job_template: "{{ tower_job_template_authenticate_tower_name }}"
+- job_template: "{{ integreatly_job_template_bootstrap_uninstall_name }}"
   success:
-  - job_template: "{{ integreatly_job_template_bootstrap_uninstall_name }}"
-    success:
-    - job_template: "{{ integreatly_job_template_uninstall_name }}"
+  - job_template: "{{ integreatly_job_template_uninstall_name }}"


### PR DESCRIPTION
**Summary**

- Adding support for concurrent Integreatly Installs
- Adding support for concurrent Integreatly Uninstalls

**Validation**
- [x] Bootstrap vanilla tower instance using this feature branch
- [x] Ensure the ATC project is pointing at this feature branch post bootstrap
- [x] Provision two new clusters via Ansible Tower jobs
- [x] Execute an Integreatly install against each cluster in parallel e.g. using `release-1.4.1-rc3` tag
- [ ] Ensure jobs are running in parallel and not pending
- [x] Execute an Integreatly uninstall against each cluster in parallel using the same tag as the install 
