### PR TITLE
URI module cert validation linked to tower_verify_ssl variable

### DIFF
--- a/playbooks/roles/tower/tasks/enable_ask_variables_on_launch.yml
+++ b/playbooks/roles/tower/tasks/enable_ask_variables_on_launch.yml
@@ -6,6 +6,7 @@
     password: "{{ tower_password }}"
     force_basic_auth: yes
     body_format: json
+    validate_certs: '{{ tower_verify_ssl }}'
   register: get_workflow_details_response
 
 - set_fact:
@@ -24,4 +25,5 @@
     password: "{{ tower_password }}"
     force_basic_auth: yes
     body_format: json
+    validate_certs: '{{ tower_verify_ssl }}'
     body: "{{ lookup('file', '/tmp/workflow_update.json')}}"


### PR DESCRIPTION
**Summary**
The `URI` module validates certs by default, thus the modules `validate_certs` option had to be manually set to `no` for clusters without valid certs. Cert validation is now associated with the`tower_verify_ssl` variable.

**Validation**
Bootstrap a tower instance and verify is completes successfully without the need to manually set the `validate certs` option of the module.