### PR TITLE
Adding storage to postgres by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The `install_tower.yml` playbook will install Ansible Tower on a target Openshif
 * `tower_openshift_master_url`: The URL of the target Openshift cluster
 
 ```bash
-ansible-playbook -i <path-to-local-credentials-project>/inventories/hosts playbooks/install_tower.yml -e tower_openshift_master_url=<tower_openshift_master_url> --ask-vault-pass
+ansible-playbook -i <path-to-local-credentials-project>/inventories/hosts playbooks/install_tower.yml -e tower_openshift_master_url=<tower_openshift_master_url> -e tower_openshift_pg_pvc_size=10Gi --ask-vault-pass
 ```
 
 A number of default values are used when installing Ansible Tower on the target Openshift cluster, any of which can be overridden with the use of environmental variables. These default values include several password values which are assigned a default value of `CHANGEME`, as can be seen below.
@@ -75,6 +75,7 @@ A number of default values are used when installing Ansible Tower on the target 
 * `tower_admin_password`: The password required to login to the newly installed Tower instance (default password is `CHANGEME`)
 * `tower_rabbitmq_password`: The password required to login to RabbitMQ (default password is `CHANGEME`)
 * `tower_pg_password`: The password required to login to PostgreSQL (default password is `CHANGEME`)
+* `tower_openshift_pg_pvc_size`: Size of Postgres persistent volume. Defaults to `100Gi` which is recommended for production environments
 
 ### 3.1 Tower Host Name Update
 

--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -92,7 +92,7 @@ tower_kubernetes_task_image: quay.io/integreatly/ansible-tower-container
 tower_kubernetes_web_image: quay.io/integreatly/ansible-tower-container
 
 tower_openshift_skip_tls_verify: true
-tower_openshift_pg_emptydir: true
+tower_openshift_pg_emptydir: false
 
 tower_dockerhub_base: ansible
 tower_create_preload_data: True
@@ -131,6 +131,7 @@ tower_pg_port: 5432
 
 tower_docker_compose_dir: /var/lib/awx
 tower_openshift_pg_pvc_name: postgresql
+tower_openshift_pg_pvc_size: 100Gi
 
 tower_default_cpu: 1500m
 tower_default_memory: 2Gi

--- a/playbooks/roles/tower/tasks/installation.yml
+++ b/playbooks/roles/tower/tasks/installation.yml
@@ -16,6 +16,14 @@
   register: limit_range_exists
   failed_when: limit_range_exists.stderr != '' and 'AlreadyExists' not in limit_range_exists.stderr
 
+- name: 'Copy the tower_pvc template'
+  template:
+    src: 'tower_pvc.yml.j2'
+    dest: '/tmp/tower_pvc.yml'
+
+- name: Create Persistent Volume {{ tower_openshift_pg_pvc_name }}
+  shell: "oc create -f /tmp/tower_pvc.yml -n {{ tower_openshift_project }}"
+
 - name: 'Download the Ansible Tower archive file'
   get_url:
     url: "{{ tower_archive_url }}"
@@ -44,3 +52,5 @@
   with_items:
     - "/tmp/{{ tower_archive_filename }}"
     - "{{ tower_install_dir }}"
+    - "/tmp/limit_range.yml"
+    - "/tmp/tower_pvc.yml"

--- a/playbooks/roles/tower/templates/tower_pvc.yml.j2
+++ b/playbooks/roles/tower/templates/tower_pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ tower_openshift_pg_pvc_name }}"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: "{{ tower_openshift_pg_pvc_size }}"


### PR DESCRIPTION
**Summary**
Currently anytime the postgres pod is re-scheduled the data in that container is lost. The purpose of this change is to add storage to postgres by default

**Validation**
- [x] Install Tower
- [x] Verify that a new storage volume exists in the tower namespace
- [x] Verify that the postgres pod is using the storage volume