### PR TITLE
Adding user_rhsso var for OSD installs

### DIFF
--- a/playbooks/roles/integreatly/files/osd_install_vars.yml
+++ b/playbooks/roles/integreatly/files/osd_install_vars.yml
@@ -29,6 +29,7 @@ run_master_tasks: false
 threescale_file_upload_storage: s3
 integreatly_operator: false 
 amq_streams: false
+user_rhsso: true
 
 pull_secret_name: registry-redhat-io-dockercfg
 


### PR DESCRIPTION
**Summary**
Adding `user_rhsso` variable override for all OSD installs. This change should be reflected following the bootstrapping of a tower instance