### PR TITLE
and cluster_type osd to vars

### DIFF
--- a/playbooks/roles/integreatly/files/osd_install_vars.yml
+++ b/playbooks/roles/integreatly/files/osd_install_vars.yml
@@ -33,3 +33,4 @@ amq_streams: false
 user_rhsso: true
 
 pull_secret_name: registry-redhat-io-dockercfg
+cluster_type: osd


### PR DESCRIPTION
The inventory can read in the cluster_type var from the ivnentory/ directory and end up with `cluster_type: rhpds` we should specifically overwrite this to osd.