### PR TITLE
use separate upgrade vars file

### DIFF
--- a/playbooks/roles/integreatly/files/osd_upgrade_vars.yml
+++ b/playbooks/roles/integreatly/files/osd_upgrade_vars.yml
@@ -1,0 +1,35 @@
+---
+openshift_asset_url: "https://console.{{ cluster_name }}.openshift.com"
+openshift_master_public_url: "https://console.{{ cluster_name }}.openshift.com"
+openshift_master_url: "https://api.{{ cluster_name }}.openshift.com"
+eval_app_host: "{{ router_shard }}.{{ cluster_name }}.openshiftapps.com"
+github_client_id: "{{ github_client_id }}"
+github_client_secret: "{{ github_client_secret }}"
+openshift_token: "{{ openshift_token }}"
+threescale_storage_s3_aws_access_key: "{{ threescale_s3_access_key }}"
+threescale_storage_s3_aws_secret_key: "{{ threescale_s3_secret_key }}"
+threescale_storage_s3_aws_bucket: "{{ threescale_s3_bucket_name }}"
+threescale_storage_s3_aws_region: "{{ threescale_s3_bucket_region }}"
+
+backup_restore_install: true
+backup_s3_aws_access_key: "{{ backup_s3_access_key }}"
+backup_s3_aws_secret_key: "{{ backup_s3_secret_key }}"
+backup_s3_aws_bucket: "{{ backup_s3_bucket_name }}"
+aws_s3_backup_secret_name: s3-credentials
+aws_s3_backup_secret_namespace: openshift-integreatly-backups
+
+create_cluster_admin: false
+eval_seed_users_count: 0
+eval_self_signed_certs: false
+gitea: false
+ns_prefix: openshift-
+openshift_login: true
+prerequisites_install: false
+run_master_tasks: false
+threescale_file_upload_storage: s3
+integreatly_operator: false 
+amq_streams: false
+user_rhsso: true
+
+pull_secret_name: registry-redhat-io-dockercfg
+cluster_type: osd

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_update.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_update.yml
@@ -72,7 +72,7 @@
     credential: "{{ tower_credential_bundle_default_name }}"
     description: Job for upgrading Integreatly on Openshift Dedicated
     state: present 
-    extra_vars_path: roles/integreatly/files/osd_install_vars.yml
+    extra_vars_path: roles/integreatly/files/osd_upgrade_vars.yml
     inventory: "{{ integreatly_osd_update_inventory }}"
     tower_verify_ssl: "{{ tower_verify_ssl }}"
   register: integreatly_deploy_out


### PR DESCRIPTION
Use a separate vars file for the upgrade job so we can manage these settings differently than install.

After this is merged I will create a release-1.4.3 which will include these changes.