### PR TITLE
Adding support for installing Tower v3.5.3

### DIFF
--- a/images/tower_base/Dockerfile
+++ b/images/tower_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ansible-tower-34/ansible-tower
+FROM registry.access.redhat.com/ansible-tower-35/ansible-tower
 
 USER root
 

--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -79,17 +79,20 @@ tower_host_local_name: 'local'
 tower_host_local_desc: ''
 
 # Ansible Tower Installation Configurations
-tower_version: '3.4.3'
+tower_version: '3.5.3'
 tower_install_dir: "/tmp/ansible-tower-openshift-setup-{{ tower_version }}"
 tower_archive_filename: "ansible-tower-openshift-setup-{{ tower_version }}.tar.gz"
 tower_archive_url: "https://releases.ansible.com/ansible-tower/setup_openshift/{{ tower_archive_filename }}"
 
-tower_kubernetes_task_version: 'latest'
-tower_kubernetes_web_version: 'latest' 
+tower_kubernetes_task_version: '3.5.3'
+tower_kubernetes_web_version: '3.5.3' 
 
 tower_kubernetes_base_path: "{{ local_base_config_path|default('/tmp') }}/{{ tower_kubernetes_deployment_name }}-config"
-tower_kubernetes_task_image: quay.io/integreatly/ansible-tower-container
-tower_kubernetes_web_image: quay.io/integreatly/ansible-tower-container
+# Remove reference to test image before merging!
+tower_kubernetes_task_image: "quay.io/integreatly/ansible-tower-container:test"
+tower_kubernetes_web_image: "quay.io/integreatly/ansible-tower-container:test"
+
+tower_kubernetes_memcached_image: registry.access.redhat.com/ansible-tower-35/ansible-tower-memcached
 
 tower_openshift_skip_tls_verify: true
 tower_openshift_pg_emptydir: false
@@ -114,7 +117,7 @@ tower_memcached_mem_request: 1
 tower_memcached_cpu_request: 500
 
 tower_kubernetes_rabbitmq_version: "3.7.4"
-tower_kubernetes_rabbitmq_image: "ansible/awx_rabbitmq"
+tower_kubernetes_rabbitmq_image: registry.access.redhat.com/ansible-tower-35/ansible-tower-messaging
 
 tower_kubernetes_deployment_name: ansible-tower
 tower_kubernetes_deployment_replica_size: 1
@@ -139,4 +142,6 @@ tower_default_memory: 2Gi
 tower_secret_key: CHANGEME
 
 tower_limit_range_name: "{{ tower_openshift_project }}-core-resource-limits"
+
+tower_insights_url_base: "https://cloud.redhat.com"
 

--- a/playbooks/roles/tower/templates/installation_vars.yml.j2
+++ b/playbooks/roles/tower/templates/installation_vars.yml.j2
@@ -6,6 +6,8 @@ kubernetes_task_image: "{{ tower_kubernetes_task_image }}"
 kubernetes_web_version: "{{ tower_kubernetes_web_version }}"
 kubernetes_web_image: "{{ tower_kubernetes_web_image }}"
 
+kubernetes_memcached_image: "{{ tower_kubernetes_memcached_image }}"
+
 kubernetes_rabbitmq_version: "{{ tower_kubernetes_rabbitmq_version }}"
 kubernetes_rabbitmq_image: "{{ tower_kubernetes_rabbitmq_image }}"
 
@@ -63,6 +65,8 @@ create_preload_data: "{{ tower_create_preload_data }}"
  
 # AWX Secret key
 secret_key: "{{ tower_secret_key }}"
+
+insights_url_base: "{{ tower_insights_url_base }}"
  
 
 


### PR DESCRIPTION
**Summary**
Upgrading to Tower v3.5.3 to support additional feature requests from QE team

**Validation Steps**
- [ ] Provision Openshift 3 cluster (optional)
- [ ] Run Tower install as per docs [1]
- [ ] Validate that v3.5.3 of Tower has been installed (info icon in top right of UI)

[1] https://github.com/integr8ly/ansible-tower-configuration#3-ansible-tower-installation