### PR TITLE
Adding support for installing Tower v3.5.3

### DIFF
--- a/images/tower_base/Dockerfile
+++ b/images/tower_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ansible-tower-34/ansible-tower
+FROM registry.access.redhat.com/ansible-tower-35/ansible-tower
 
 USER root
 
@@ -12,8 +12,8 @@ RUN rpm --import /tmp/centos-key && \
     yum-config-manager --add-repo=http://mirror.centos.org/centos-7/7/os/x86_64/ && \
     yum-config-manager --add-repo=http://mirror.centos.org/centos/7/updates/x86_64/ && \
     rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum -y install unzip httpd-tools java-1.8.0-openjdk-headless dh-autoreconf && \
-    sh -c "git clone https://github.com/ansible/tower-cli.git ; cd tower-cli ; make install" && \
+    yum -y install unzip httpd-tools java-1.8.0-openjdk-headless dh-autoreconf python-pip && \
+    pip install ansible-tower-cli && \
     sh -c "tar -xzf /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit.tar.gz -C /tmp/" && \
     sh -c "mv /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit/oc /usr/bin/oc" && \ 
     sh -c "rm /tmp/openshift-origin-server-v3.11.0-0cbc58b-linux-64bit.tar.gz" && \

--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -79,17 +79,19 @@ tower_host_local_name: 'local'
 tower_host_local_desc: ''
 
 # Ansible Tower Installation Configurations
-tower_version: '3.4.3'
+tower_version: '3.5.3'
 tower_install_dir: "/tmp/ansible-tower-openshift-setup-{{ tower_version }}"
 tower_archive_filename: "ansible-tower-openshift-setup-{{ tower_version }}.tar.gz"
 tower_archive_url: "https://releases.ansible.com/ansible-tower/setup_openshift/{{ tower_archive_filename }}"
 
-tower_kubernetes_task_version: 'latest'
-tower_kubernetes_web_version: 'latest' 
-
+tower_kubernetes_task_version: '3.5.3'
+tower_kubernetes_web_version: '3.5.3' 
 tower_kubernetes_base_path: "{{ local_base_config_path|default('/tmp') }}/{{ tower_kubernetes_deployment_name }}-config"
-tower_kubernetes_task_image: quay.io/integreatly/ansible-tower-container
-tower_kubernetes_web_image: quay.io/integreatly/ansible-tower-container
+
+tower_kubernetes_task_image: "quay.io/integreatly/ansible-tower-container"
+tower_kubernetes_web_image: "quay.io/integreatly/ansible-tower-container"
+
+tower_kubernetes_memcached_image: registry.access.redhat.com/ansible-tower-35/ansible-tower-memcached
 
 tower_openshift_skip_tls_verify: true
 tower_openshift_pg_emptydir: false
@@ -114,7 +116,7 @@ tower_memcached_mem_request: 1
 tower_memcached_cpu_request: 500
 
 tower_kubernetes_rabbitmq_version: "3.7.4"
-tower_kubernetes_rabbitmq_image: "ansible/awx_rabbitmq"
+tower_kubernetes_rabbitmq_image: registry.access.redhat.com/ansible-tower-35/ansible-tower-messaging
 
 tower_kubernetes_deployment_name: ansible-tower
 tower_kubernetes_deployment_replica_size: 1
@@ -139,4 +141,6 @@ tower_default_memory: 2Gi
 tower_secret_key: CHANGEME
 
 tower_limit_range_name: "{{ tower_openshift_project }}-core-resource-limits"
+
+tower_insights_url_base: "https://cloud.redhat.com"
 

--- a/playbooks/roles/tower/templates/installation_vars.yml.j2
+++ b/playbooks/roles/tower/templates/installation_vars.yml.j2
@@ -6,6 +6,8 @@ kubernetes_task_image: "{{ tower_kubernetes_task_image }}"
 kubernetes_web_version: "{{ tower_kubernetes_web_version }}"
 kubernetes_web_image: "{{ tower_kubernetes_web_image }}"
 
+kubernetes_memcached_image: "{{ tower_kubernetes_memcached_image }}"
+
 kubernetes_rabbitmq_version: "{{ tower_kubernetes_rabbitmq_version }}"
 kubernetes_rabbitmq_image: "{{ tower_kubernetes_rabbitmq_image }}"
 
@@ -63,6 +65,8 @@ create_preload_data: "{{ tower_create_preload_data }}"
  
 # AWX Secret key
 secret_key: "{{ tower_secret_key }}"
+
+insights_url_base: "{{ tower_insights_url_base }}"
  
 
 


### PR DESCRIPTION
**Summary**
Upgrading to Tower v3.5.3 to support additional feature requests from QE team

**Validation Steps**
- [x] Provision Openshift 3 cluster (optional)
- [x] Checkout `master` branch of https://github.com/RHCloudServices/integreatly_dev locally
- [x] Run Tower install from this repo and feature branch
```
ansible-playbook -i <path-to-integreatly_dev>/inventories/hosts playbooks/install_tower.yml -e tower_openshift_master_url=https://<openshift-master-url> -e tower_openshift_username=<cluster-admin-username> -e tower_openshift_password=<cluster-admin-password> -e tower_openshift_project=<tower-namespace> -e tower_openshift_pg_pvc_size=10Gi --ask-vault-pass
```
- [ ] Validate that v3.5.3 of Tower has been installed (info icon in top right of UI)