### PR TITLE
Setting Job Concurrency flag on OSD workflows

### DIFF
--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -131,7 +131,7 @@ integreatly_osd_install_desc: "Integreatly Project: {{ integreatly_osd_install_b
 integreatly_osd_install_org: integreatly
 integreatly_osd_install_inventory: OSD_Tower_Install_Inventory
 integreatly_osd_install_source_name:  installation-project-source
-integreatly_osd_install_source_path: "inventories/{{ integreatly_install_type }}.template"
+integreatly_osd_install_source_path: "inventories/osd.template"
 integreatly_osd_install_name: "Integreatly_Install_Template_[OSD]"
 integreatly_osd_bootstrap_name: "Integreatly_Bootstrap_Template_[OSD]"
 integreatly_osd_workflow_name: "Integreatly_Bootstrap_and_Install_[OSD]"
@@ -146,7 +146,7 @@ integreatly_osd_uninstall_desc: "Integreatly Project: {{ integreatly_osd_uninsta
 integreatly_osd_uninstall_org: integreatly
 integreatly_osd_uninstall_inventory: OSD_Tower_Uninstall_Inventory
 integreatly_osd_uninstall_source_name:  uninstall-project-source
-integreatly_osd_uninstall_source_path: "inventories/{{ integreatly_install_type }}.template"
+integreatly_osd_uninstall_source_path: "inventories/osd.template"
 integreatly_osd_uninstall_name: "Integreatly_Uninstall_Template_[OSD]"
 integreatly_osd_uninstall_bootstrap_name: "Integreatly_Bootstrap_Uninstall_Template_[OSD]"
 integreatly_osd_uninstall_workflow_name: "Integreatly_Bootstrap_and_Uninstall_[OSD]"

--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -137,6 +137,7 @@ integreatly_osd_bootstrap_name: "Integreatly_Bootstrap_Template_[OSD]"
 integreatly_osd_workflow_name: "Integreatly_Bootstrap_and_Install_[OSD]"
 integreatly_osd_workflow_description: "Workflow to configure and install integreatly on an OSD cluster"
 integreatly_osd_source_project_update_on_launch: true
+integreatly_osd_install_workflow_job_concurrency: True
 
 # OSD uninstall
 integreatly_osd_uninstall_branch: "{{ integreatly_version }}"
@@ -151,6 +152,7 @@ integreatly_osd_uninstall_bootstrap_name: "Integreatly_Bootstrap_Uninstall_Templ
 integreatly_osd_uninstall_workflow_name: "Integreatly_Bootstrap_and_Uninstall_[OSD]"
 integreatly_osd_uninstall_workflow_description: "Workflow to uninstall integreatly from an OSD cluster"
 integreatly_osd_uninstall_source_project_update_on_launch: true
+integreatly_osd_uninstall_workflow_job_concurrency: True
 
 # OSD upgrade
 integreatly_osd_update_branch: "{{ integreatly_version }}"
@@ -160,3 +162,4 @@ integreatly_osd_upgrade_name: "Integreatly_Upgrade_[OSD]"
 integreatly_osd_upgrade_workflow_name: "Integreatly_Bootstrap_and_Upgrade_[OSD]"
 integreatly_osd_upgrade_desc: "Workflow to upgrade integreatly on an OSD cluster"
 integreatly_osd_update_inventory: OSD_update_inventory
+integreatly_osd_upgrade_workflow_job_concurrency: True

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall_workflow.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall_workflow.yml
@@ -8,6 +8,7 @@
     state: present
     organization: "{{ integreatly_osd_uninstall_org }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    allow_simultaneous: "{{ integreatly_osd_uninstall_workflow_job_concurrency }}"
   register: create_workflow_response
 
 - name: Create uninstall workflow schema

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_update_workflow.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_update_workflow.yml
@@ -8,6 +8,7 @@
     state: present
     organization: "{{ integreatly_osd_install_org }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    allow_simultaneous: "{{ integreatly_osd_upgrade_workflow_job_concurrency }}"
   register: create_workflow_response
 
 - name: Create upgrade workflow schema

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_workflow.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_workflow.yml
@@ -8,6 +8,7 @@
     state: present
     organization: "{{ integreatly_osd_install_org }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+    allow_simultaneous: "{{ integreatly_osd_install_workflow_job_concurrency }}"
   register: create_workflow_response
 
 - name: Create install workflow schema


### PR DESCRIPTION
It looks like we don't currently set the "Enable Job Concurrency" flag on OSD install, uninstall and upgrade workflow jobs.

The purpose of this PR is to address this issue.