### PR TITLE
Allow tower_provisioner cred to have password for user

### DIFF
--- a/playbooks/roles/tower/tasks/bootstrap_credentials.yml
+++ b/playbooks/roles/tower/tasks/bootstrap_credentials.yml
@@ -40,7 +40,7 @@
     ssh_key_data: '/tmp/tower_ssh'
     ssh_key_unlock: '{{ tower_ssh_password }}'
     username: '{{ tower_ssh_user }}'
-    password: '{{ tower_ssh_user_pass }}'
+    password: '{{ tower_ssh_user_password }}'
     tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Create AWS Credentials'

--- a/playbooks/roles/tower/tasks/bootstrap_credentials.yml
+++ b/playbooks/roles/tower/tasks/bootstrap_credentials.yml
@@ -40,6 +40,7 @@
     ssh_key_data: '/tmp/tower_ssh'
     ssh_key_unlock: '{{ tower_ssh_password }}'
     username: '{{ tower_ssh_user }}'
+    password: '{{ tower_ssh_user_pass }}'
     tower_verify_ssl: '{{ tower_verify_ssl }}'
 
 - name: 'Create AWS Credentials'


### PR DESCRIPTION
We can't bootstrap SRE prod Tower until we merge this and add it to the next tag release. We require root user password so we can do ssh tunnel to private clusters. 

This will also involve a PR to integreatly_dev creds repo to stop this failing for dev clusters. Just add 
`tower_ssh_user_pass:''` here - https://github.com/RHCloudServices/integreatly_dev/blob/master/inventories/group_vars/all/tower_ssh.yml#L3

CC @pmccarthy 
