### PR TITLE
Updating tower_credential_bundle to allow for become details

### DIFF
--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -29,6 +29,7 @@ tower_credential_bundle_vault_type: 'vault'
 tower_credential_bundle_default_name: 'tower_provisioner'
 tower_credential_bundle_default_desc: 'Default Tower machine credential'
 tower_credential_bundle_default_type: 'ssh'
+tower_credential_bundle_become_method: 'su'
 
 tower_credential_bundle_github_name: "tower_github_scm"
 tower_credential_bundle_github_desc: "Default Tower Credential Bundle for Github"

--- a/playbooks/roles/tower/tasks/bootstrap_credentials.yml
+++ b/playbooks/roles/tower/tasks/bootstrap_credentials.yml
@@ -36,6 +36,8 @@
     description: '{{ tower_credential_bundle_default_desc }}'
     organization: '{{ tower_organization }}'
     state: present
+    become_method: '{{ tower_credential_bundle_become_method }}'
+    become_password: '{{ tower_ssh_become_password }}'
     kind: '{{ tower_credential_bundle_default_type }}'
     ssh_key_data: '/tmp/tower_ssh'
     ssh_key_unlock: '{{ tower_ssh_password }}'
@@ -54,3 +56,5 @@
     password: '{{ lookup("vars", "_".join((item, "secret_access_key")) ) }}'
     tower_verify_ssl: '{{ tower_verify_ssl }}'
   with_items: '{{ aws_credential_list }}'
+
+


### PR DESCRIPTION
@pmccarthy  Can you please review? This is needed as SRE need to use become as part of SSH tunnel piece. I've tested this against the SRE dev tower.

Once merged, you'll need to update the engineering creds repo to include:

`tower_ssh_become_password: ''`