### PR TITLE
Adding support for CVE Rollout workflow job

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ make image/push
 The `install_tower.yml` playbook will install Ansible Tower on a target Openshift cluster. The playbook requires the target tower environment to be specified.
 
 * `tower_openshift_master_url`: The URL of the target Openshift cluster
+* `tower_openshift_username`: Cluster admin user on target Openshift cluster
+* `tower_openshift_password`: Password of cluster admin user on target Openshift Cluster
 
 ```bash
-ansible-playbook -i <path-to-local-credentials-project>/inventories/hosts playbooks/install_tower.yml -e tower_openshift_master_url=<tower_openshift_master_url> -e tower_openshift_pg_pvc_size=10Gi --ask-vault-pass
+ansible-playbook -i <path-to-local-credentials-project>/inventories/hosts playbooks/install_tower.yml -e tower_openshift_master_url=<tower_openshift_master_url> -e tower_openshift_username=<tower_openshift_cluster_admin_username> -e tower_openshift_password=<tower_openshift_cluster_admin_password> -e tower_openshift_pg_pvc_size=10Gi --ask-vault-pass
 ```
 
 A number of default values are used when installing Ansible Tower on the target Openshift cluster, any of which can be overridden with the use of environmental variables. These default values include several password values which are assigned a default value of `CHANGEME`, as can be seen below.
@@ -107,7 +109,7 @@ ansible-playbook -i <path-to-local-credentials-project>/inventories/hosts playbo
 If you also wish to bootstrap the tower instance with the OSD integreatly install workflow you need to run this play after running the bootstrap.yml play.
 
 ```bash
-ansible-playbook -i inventories/hosts playbooks/bootstrap_osd_integreatly_install.yml -e tower_environment=<tower-environment>
+ansible-playbook -i <path-to-local-credentials-project>/inventories/hosts playbooks/bootstrap_osd_integreatly_install.yml -e tower_environment=<tower-environment> --ask-vault-pass
 ```
 
 This will create the resources necessary to use the *Integreatly_Bootstrap_and_install_[OSD]* workflow which will install Integreatly on a targeted OSD cluster.

--- a/playbooks/bootstrap_osd_integreatly_install.yml
+++ b/playbooks/bootstrap_osd_integreatly_install.yml
@@ -13,4 +13,7 @@
     - include_role:
         name: integreatly
         tasks_from: bootstrap_osd_uninstall_workflow.yml
+    - include_role:
+        name: integreatly
+        tasks_from: bootstrap_osd_cve_rollout_workflow.yml
     

--- a/playbooks/osd_integreatly_cve_rollout.yml
+++ b/playbooks/osd_integreatly_cve_rollout.yml
@@ -1,0 +1,11 @@
+---
+- import_playbook: "./authenticate_tower.yml"
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_vars:
+        ./roles/tower/defaults/main.yml
+    - include_role:
+        name: integreatly
+        tasks_from: bootstrap_osd_cve_rollout.yml

--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -163,3 +163,34 @@ integreatly_osd_upgrade_workflow_name: "Integreatly_Bootstrap_and_Upgrade_[OSD]"
 integreatly_osd_upgrade_desc: "Workflow to upgrade integreatly on an OSD cluster"
 integreatly_osd_update_inventory: OSD_update_inventory
 integreatly_osd_upgrade_workflow_job_concurrency: True
+
+# OSD CVE Rollouts
+integreatly_osd_cve_rollout_workflow_name: "Integreatly_CVE_rollout_[OSD]"
+integreatly_osd_cve_rollout_workflow_desc: "Workflow for rolling out CVEs to OSD"
+integreatly_osd_cve_rollout_workflow_job_concurrency: True
+
+integreatly_osd_cve_rollout_job_template_name: "Integreatly_CVE_Rollout_Job_Template_[OSD]"
+integreatly_osd_cve_rollout_job_template_desc: "Job template for rolling out CVEs to OSD"
+integreatly_osd_cve_rollout_job_template_concurrency: True
+
+integreatly_osd_cve_rollout_bootstrap_name: "Integreatly_CVE_Bootstrap_Template_[OSD]"
+integreatly_osd_cve_rollout_bootstrap_desc: "Job template for bootstrapping CVE rollout jobs on OSD"
+integreatly_osd_cve_rollout_bootstrap_concurrency: True
+
+integreatly_osd_cve_rollout_project_branch: "{{ integreatly_version }}"
+integreatly_osd_cve_rollout_project_name: "integreatly-cve-{{ integreatly_osd_cve_rollout_project_branch }}"
+integreatly_osd_cve_rollout_project_desc: "Project for CVE rollouts"
+integreatly_osd_cve_rollout_project_scm_type: git
+integreatly_osd_cve_rollout_project_scm_url: 'git@github.com:integr8ly/installation.git'
+integreatly_osd_cve_rollout_project_scm_clean: true
+integreatly_osd_cve_rollout_project_scm_update_on_launch: false
+integreatly_osd_cve_rollout_project_scm_delete_on_update: true
+
+integreatly_osd_cve_rollout_org: integreatly
+integreatly_osd_cve_rollout_inventory_name: OSD_cve_inventory
+integreatly_osd_cve_rollout_inventory_desc: "Inventory for OSD CVE Rollouts"
+integreatly_osd_cve_rollout_product_tags: ''
+
+integreatly_osd_cve_rollout_source_name: cve-project-source
+integreatly_osd_cve_rollout_source_project_on_launch: true
+integreatly_osd_cve_rollout_source_path: "inventories/osd.template"

--- a/playbooks/roles/integreatly/files/osd_cve_rollout_survey.json
+++ b/playbooks/roles/integreatly/files/osd_cve_rollout_survey.json
@@ -1,0 +1,63 @@
+{
+    "description": "",
+    "name": "",
+    "spec": [
+      {
+        "question_description": "Name of target cluster for CVE rollout",
+        "min": 0,
+        "default": "",
+        "max": 20,
+        "required": true,
+        "choices": "",
+        "variable": "cluster_name",
+        "question_name": "Cluster Name",
+        "type": "text"
+      },
+      {
+        "question_description": "Router shard of the target cluster",
+        "min": 0,
+        "default": "",
+        "max": 5,
+        "required": true,
+        "choices": "",
+        "variable": "router_shard",
+        "question_name": "Router shard",
+        "type": "text"
+      },
+      {
+        "question_description": "Integreatly Installer Git branch/tag for CVE rollout",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "new_question": true,
+        "variable": "integreatly_osd_cve_rollout_project_branch",
+        "question_name": "Integreatly CVE rollout branch/tag",
+        "type": "text"
+      },
+      {
+        "question_description": "Openshift token for cluster-admin user on target cluster",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": true,
+        "choices": "",
+        "new_question": true,
+        "variable": "openshift_token",
+        "question_name": "Openshift token",
+        "type": "password"
+      },
+      {
+        "question_description": "Comma separated list of product tags e.g. 3scale,rhsso",
+        "min": 0,
+        "default": "",
+        "max": 1024,
+        "required": false,
+        "choices": "",
+        "variable": "integreatly_osd_cve_rollout_product_tags",
+        "question_name": "Product Specific Tags [Optional]",
+        "type": "text"
+      }
+    ]
+  }

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_cve_rollout.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_cve_rollout.yml
@@ -33,6 +33,13 @@
     state: present
     tower_verify_ssl: "{{ tower_verify_ssl }}"
 
+- name: "Sync project: {{ integreatly_osd_cve_rollout_project_name }}"
+  shell: "tower-cli project update -n {{ integreatly_osd_cve_rollout_project_name }}"
+  register: cve_project_update
+  retries: 10
+  delay: 3
+  until: cve_project_update.rc == 0
+
 - name: Create inventory source for OSD CVE inventory
   tower_inventory_source:
     name: "{{ integreatly_osd_cve_rollout_source_name }}"

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_cve_rollout.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_cve_rollout.yml
@@ -1,0 +1,84 @@
+---
+- name: "Create integreatly CVE project: {{ integreatly_osd_cve_rollout_project_name }}"
+  tower_project:
+    name: "{{ integreatly_osd_cve_rollout_project_name }}"
+    description: "{{ integreatly_osd_cve_rollout_project_desc }}"
+    organization: "{{ integreatly_osd_cve_rollout_org }}"
+    state: present
+    scm_type: "{{ integreatly_osd_cve_rollout_project_scm_type }}"
+    scm_url: "{{ integreatly_osd_cve_rollout_project_scm_url }}"
+    scm_branch: "{{ integreatly_osd_cve_rollout_project_branch }}"
+    scm_clean: "{{ integreatly_osd_cve_rollout_project_scm_clean }}"
+    scm_update_on_launch: "{{ integreatly_osd_cve_rollout_project_scm_update_on_launch }}"
+    scm_delete_on_update: "{{ integreatly_osd_cve_rollout_project_scm_delete_on_update }}"
+    scm_credential: "{{ integreatly_credential_bundle_github_name }}"
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+  register: integreatly_cve_rollout_output
+  until: integreatly_cve_rollout_output is succeeded
+  retries: 10
+  delay: 5
+
+- name: Wait for project to be successfully synced to tower
+  shell: tower-cli project status {{ integreatly_cve_rollout_output.id }} 
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
+
+- name: Create OSD CVE inventory in tower
+  tower_inventory:
+    name: "{{ integreatly_osd_cve_rollout_inventory_name }}"
+    description: "{{ integreatly_osd_cve_rollout_inventory_desc }}"
+    organization: "{{ integreatly_osd_cve_rollout_org }}"
+    state: present
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+
+- name: Create inventory source for OSD CVE inventory
+  tower_inventory_source:
+    name: "{{ integreatly_osd_cve_rollout_source_name }}"
+    inventory: "{{ integreatly_osd_cve_rollout_inventory_name }}"
+    source: "{{ integreatly_inventory_source_project_type }}"
+    description: "From Project: {{ integreatly_osd_cve_rollout_project_name }}"
+    overwrite: "{{ integreatly_inventory_source_project_overwrite }}"
+    overwrite_vars: "{{ integreatly_inventory_source_project_overwrite_vars }}"
+    update_on_launch: "{{ integreatly_osd_cve_rollout_source_project_on_launch }}"
+    source_project: "{{ integreatly_osd_cve_rollout_project_name }}"
+    source_path: "{{ integreatly_osd_cve_rollout_source_path }}"
+    state: present
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+  register: integreatly_cve_rollout_source_output
+  until: integreatly_cve_rollout_source_output is succeeded
+  retries: 10
+  delay: 5
+
+- name: Create OSD Integreatly bootstrap CVE job template
+  tower_job_template:
+    name: "{{ integreatly_osd_cve_rollout_bootstrap_name }}"
+    description: "{{ integreatly_osd_cve_rollout_bootstrap_desc }}"
+    project: "{{ tower_configuration_project_name }}"
+    job_type: run
+    playbook: playbooks/osd_integreatly_cve_rollout.yml
+    credential: "{{ tower_credential_bundle_default_name }}"
+    state: present 
+    inventory: "{{ tower_inventory_name }}"
+    vault_credential: '{{ tower_credential_bundle_vault_name }}'
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+
+- name: Create OSD Integreatly CVE job template
+  tower_job_template:
+    name: "{{ integreatly_osd_cve_rollout_job_template_name }}"
+    description: "{{ integreatly_osd_cve_rollout_job_template_desc }}"
+    project: "{{ integreatly_osd_cve_rollout_project_name }}"
+    job_type: run
+    playbook: "playbooks/cve_rollout.yml"
+    credential: "{{ tower_credential_bundle_default_name }}"
+    state: present 
+    inventory: "{{ integreatly_osd_cve_rollout_inventory_name }}"
+    tower_verify_ssl: "{{ tower_verify_ssl }}"
+  register: integreatly_cve_rollout_output
+  until: integreatly_cve_rollout_output is succeeded
+  retries: 10
+  delay: 5
+
+- name: "Update CVE job template: {{ integreatly_osd_cve_rollout_job_template_name }}"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_osd_cve_rollout_job_template_name }}\" --project {{ integreatly_osd_cve_rollout_project_name }} --playbook playbooks/cve_rollout.yml {% if integreatly_osd_cve_rollout_product_tags != '' %} --job-tags {{ integreatly_osd_cve_rollout_product_tags }} {% endif %}"

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_cve_rollout_workflow.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_cve_rollout_workflow.yml
@@ -1,0 +1,34 @@
+---
+- include_tasks: bootstrap_osd_cve_rollout.yml
+
+- name: "Create workflow: {{ integreatly_osd_cve_rollout_workflow_name }}"
+  tower_workflow_template:
+    name:  "{{ integreatly_osd_cve_rollout_workflow_name }}"
+    description: "{{ integreatly_osd_cve_rollout_workflow_desc }}"
+    state: present
+    organization: "{{ integreatly_osd_cve_rollout_org }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+    allow_simultaneous: "{{ integreatly_osd_cve_rollout_workflow_job_concurrency }}"
+  register: create_workflow_response
+
+- name: Create CVE rollout workflow schema
+  template:
+    src: osd_workflow_cve_rollout_schema.yml.j2
+    dest: "/tmp/osd_workflow_cve_rollout_schema.yml"
+
+- name: Update CVE workflow job template with survey
+  shell: "tower-cli workflow modify --name=\"{{ integreatly_osd_cve_rollout_workflow_name }}\" --survey-enabled=true --survey-spec='@{{ role_path }}/files/osd_cve_rollout_survey.json'"
+
+- name: Update CVE workflow job template with schema
+  shell: "tower-cli workflow schema \"{{ integreatly_osd_cve_rollout_workflow_name }}\" @/tmp/osd_workflow_cve_rollout_schema.yml"
+
+# Update the workflow to enable ask_variables_on_launch via the tower api
+- include_role:
+    name: tower
+    tasks_from: enable_ask_variables_on_launch.yml
+  vars:
+    workflow_id: "{{ create_workflow_response.id }}"
+
+- name: Cleanup temp CVE rollout workflow files
+  file:
+    path: "/tmp/osd_workflow_cve_rollout_schema.yml"

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall.yml
@@ -33,6 +33,13 @@
     state: present
     tower_verify_ssl: "{{ tower_verify_ssl }}"
 
+- name: "Sync project: integreatly-uninstall-{{ integreatly_osd_uninstall_branch }}"
+  shell: "tower-cli project update -n integreatly-uninstall-{{ integreatly_osd_uninstall_branch }}"
+  register: uninstall_project_update
+  retries: 10
+  delay: 3
+  until: uninstall_project_update.rc == 0
+
 - name: Create inventory source for OSD inventory
   tower_inventory_source:
     name: "{{ integreatly_osd_uninstall_source_name }}"

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_update.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_update.yml
@@ -33,6 +33,13 @@
     state: present
     tower_verify_ssl: "{{ tower_verify_ssl }}"
 
+- name: "Sync project: integreatly-update-{{ integreatly_osd_update_branch }}"
+  shell: "tower-cli project update -n integreatly-update-{{ integreatly_osd_update_branch }}"
+  register: update_project_update
+  retries: 10
+  delay: 3
+  until: update_project_update.rc == 0
+
 - name: Create inventory source for OSD update inventory
   tower_inventory_source:
     name: "{{ integreatly_osd_upgrade_source_name }}"

--- a/playbooks/roles/integreatly/templates/osd_workflow_cve_rollout_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/osd_workflow_cve_rollout_schema.yml.j2
@@ -1,0 +1,4 @@
+---
+- job_template: "{{ integreatly_osd_cve_rollout_bootstrap_name }}"
+  success:
+  - job_template: "{{ integreatly_osd_cve_rollout_job_template_name }}"


### PR DESCRIPTION
**Summary**
To support automated CVE rollouts for production OSD 3x clusters, we need to have a tower workflow job in place that can perform these rollouts.

**Validation**
- [x] Install Tower instance
- [x] Bootstrap tower using this feature branch
- [x] Execute CVE rollout job against OSD cluster with pre-existing RHMI installation

**Related PR**
https://github.com/integr8ly/installation/pull/1142