### PR TITLE
Fixing timeouts issues with OSD workflow project sync

### DIFF
--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_cve_rollout.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_cve_rollout.yml
@@ -18,7 +18,7 @@
   retries: 10
   delay: 5
 
-- name: Wait for project to be successfully synced to tower
+- name: Wait for CVE project {{ integreatly_osd_cve_rollout_project_name }} to be synced
   shell: tower-cli project status {{ integreatly_cve_rollout_output.id }} 
   register: integreatly_sync_out
   until: integreatly_sync_out.stdout.find("successful") != -1
@@ -39,6 +39,13 @@
   retries: 10
   delay: 3
   until: cve_project_update.rc == 0
+
+- name: Wait for CVE project {{ integreatly_osd_cve_rollout_project_name }} to be synced
+  shell: tower-cli project status {{ integreatly_cve_rollout_output.id }}
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: Create inventory source for OSD CVE inventory
   tower_inventory_source:

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_install.yml
@@ -18,7 +18,7 @@
   retries: 10
   delay: 5
 
-- name: Wait for project to be successfully synced to tower
+- name: Wait for install project integreatly-install-{{ integreatly_osd_install_branch }} to be synced
   shell: tower-cli project status {{ integreatly_install_out.id }} 
   register: integreatly_sync_out
   until: integreatly_sync_out.stdout.find("successful") != -1
@@ -39,6 +39,13 @@
   retries: 10
   delay: 3
   until: install_project_update.rc == 0
+
+- name: Wait for install project integreatly-install-{{ integreatly_osd_install_branch }} to be synced
+  shell: tower-cli project status {{ integreatly_install_out.id }}
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: Create inventory source for OSD inventory
   tower_inventory_source:

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall.yml
@@ -18,7 +18,7 @@
   retries: 10
   delay: 5
 
-- name: Wait for project to be successfully synced to tower
+- name: Wait for uninstall project integreatly-uninstall-{{ integreatly_osd_uninstall_branch }} to be synced
   shell: tower-cli project status {{ integreatly_uninstall_out.id }} 
   register: integreatly_sync_out
   until: integreatly_sync_out.stdout.find("successful") != -1
@@ -39,6 +39,14 @@
   retries: 10
   delay: 3
   until: uninstall_project_update.rc == 0
+
+  
+- name: Wait for uninstall project integreatly-uninstall-{{ integreatly_osd_uninstall_branch }} to be synced
+  shell: tower-cli project status {{ integreatly_uninstall_out.id }} 
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: Create inventory source for OSD inventory
   tower_inventory_source:

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_update.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_update.yml
@@ -18,7 +18,7 @@
   retries: 10
   delay: 5
 
-- name: Wait for project to be successfully synced to tower
+- name: Wait for update project integreatly-update-{{ integreatly_osd_update_branch }} to be synced
   shell: tower-cli project status {{ integreatly_update_out.id }} 
   register: integreatly_sync_out
   until: integreatly_sync_out.stdout.find("successful") != -1
@@ -39,6 +39,13 @@
   retries: 10
   delay: 3
   until: update_project_update.rc == 0
+
+- name: Wait for update project integreatly-update-{{ integreatly_osd_update_branch }} to be synced
+  shell: tower-cli project status {{ integreatly_update_out.id }} 
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: Create inventory source for OSD update inventory
   tower_inventory_source:


### PR DESCRIPTION
**Summary**
Noticed a timing issue when pulling in latest changes from source project as part of the OSD workflow bootstrap stages. We aren't waiting for the project to finish syncing on an update which leads to an error due to the project update not completing before the inventory source tries to sync.

**Validation**
- [x] Validate OSD Uninstall
- [x] Validate OSD Install (release-1.5.1)
- [x] Validate OSD Upgrade (release-1.5.2)
- [x] Validate OSD CVE Rollout