### PR TITLE
Fix POC Install Parsing issue

### DIFF
--- a/playbooks/roles/integreatly/tasks/bootstrap_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_install.yml
@@ -22,6 +22,14 @@
     scm_delete_on_update: "{{ integreatly_project_install_scm_delete_on_update }}"
     scm_credential: "{{ integreatly_credential_bundle_github_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: integreatly_install_project
+
+- name: Wait for install project {{ integreatly_project_install_name }} to be synced
+  shell: tower-cli project status {{ integreatly_install_project.id }}
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: "Sync project: {{ integreatly_project_install_name }}"
   shell: "tower-cli project update -n {{ integreatly_project_install_name }}"
@@ -29,6 +37,13 @@
   retries: 10
   delay: 3
   until: install_project_update.rc == 0
+
+- name: Wait for install project {{ integreatly_project_install_name }} to be synced
+  shell: tower-cli project status {{ integreatly_install_project.id }}
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: "Create inventory source AWS: {{ integreatly_inventory_source_aws_name }}"
   tower_inventory_source:
@@ -44,6 +59,7 @@
     instance_filters: "{{ integreatly_inventory_source_aws_instance_filters }}"
     state: present
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: integreatly_inventory_aws_source
 
 - name: "Create inventory source from Project: {{ integreatly_project_install_name }}"
   tower_inventory_source:
@@ -58,12 +74,27 @@
     source_path: "{{ integreatly_inventory_source_project_path }}"
     state: present
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: integreatly_inventory_project_source
 
 - name: "Sync inventory sources"
   shell: "tower-cli inventory_source update {{ item }}"
   with_items:
     - "{{ integreatly_inventory_source_aws_name }}"
     - "{{ integreatly_inventory_source_project_name }}"
+
+- name: "Wait for inventory source Project: {{ integreatly_inventory_source_project_name }} to be synced"
+  shell: tower-cli inventory_source status {{ integreatly_inventory_project_source.id }}
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
+
+- name: "Wait for inventory source AWS: {{ integreatly_inventory_source_aws_name }} to be synced"
+  shell: tower-cli inventory_source status {{ integreatly_inventory_aws_source.id }}
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: "Create master group: {{ integreatly_group_master_name }}"
   tower_group:

--- a/playbooks/roles/integreatly/tasks/bootstrap_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_install.yml
@@ -140,7 +140,7 @@
   register: cluster_provisioning_vars_raw
 
 - set_fact:
-    cluster_provisioning_vars: "{{ cluster_provisioning_vars_raw.stdout | from_json }}"
+    cluster_provisioning_vars: "{{ cluster_provisioning_vars_raw.stdout | from_yaml }}"
 
 - set_fact:
     cluster_aws_region: "{{ cluster_provisioning_vars['openshift_aws_region'] }}"

--- a/playbooks/roles/integreatly/tasks/bootstrap_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_uninstall.yml
@@ -14,6 +14,14 @@
     scm_delete_on_update: "{{ integreatly_project_uninstall_scm_delete_on_update }}"
     scm_credential: "{{ integreatly_credential_bundle_github_name }}"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: integreatly_uninstall_project
+
+- name: Wait for uninstall project {{ integreatly_project_uninstall_name }} to be synced
+  shell: tower-cli project status {{ integreatly_uninstall_project.id }}
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: "Sync project: {{ integreatly_project_uninstall_name }}"
   shell: "tower-cli project update -n {{ integreatly_project_uninstall_name }}"
@@ -21,6 +29,13 @@
   retries: 10
   delay: 3
   until: uninstall_project_update.rc == 0
+
+- name: Wait for uninstall project {{ integreatly_project_uninstall_name }} to be synced
+  shell: tower-cli project status {{ integreatly_uninstall_project.id }}
+  register: integreatly_sync_out
+  until: integreatly_sync_out.stdout.find("successful") != -1
+  retries: 10
+  delay: 5
 
 - name: "Update workflow stage {{ integreatly_job_template_uninstall_name }}"
   shell: "tower-cli job_template modify -n \"{{ integreatly_job_template_uninstall_name }}\" -i {{ integreatly_inventory_name }} --project {{ integreatly_project_uninstall_name }} --playbook {{ integreatly_job_template_uninstall_playbook }} --credential {{ tower_credential_bundle_default_name }}"


### PR DESCRIPTION
**Summary**
At the moment there are issues with installing RHMI on POC clusters via tower. The following parse error is being thrown:

```
the field 'args' has an invalid value ({u'cluster_provisioning_vars': u'{{ cluster_provisioning_vars_raw.stdout | from_json }}'}), and could not be converted to an dict
```

The changes in this PR should resolve this issue.

Also fixing timing issues with bootstrap project sync tasks.

**Validation**
Bootstrap tower instance with this feature branch
- [x] Create POC cluster
- [x] Install RHMI on POC cluster
- [x] Uninstall RHMI from POC cluster
- [x] Deprovision POC cluster