### PR TITLE
Updating uninstall survey to use set INTLY version

### DIFF
--- a/playbooks/roles/integreatly/templates/workflow_uninstall_survey.json.j2
+++ b/playbooks/roles/integreatly/templates/workflow_uninstall_survey.json.j2
@@ -63,7 +63,7 @@
       {
         "question_description": "Integreatly Installer Git Ref",
         "min": 0,
-        "default": "master",
+        "default": "{{ integreatly_version }}",
         "max": 1024,
         "required": true,
         "choices": "",


### PR DESCRIPTION
**Summary**
The Integreatly uninstall survey has a hardcoded reference to master for the git branch/tag. This should instead read in the version of Integreatly that gets set in the integreatly role i.e. https://github.com/integr8ly/ansible-tower-configuration/blob/master/playbooks/roles/integreatly/defaults/main.yml#L11 