### PR TITLE
Adding support for OSD bootstrap to remove job template extra vars

### DIFF
--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_install.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_install.yml
@@ -94,6 +94,11 @@
   retries: 10
   delay: 5
 
+# tower_job_template only allows a template YAML file to be provided when setting extra vars
+# Setting it to blank via tower-cli
+- name: "Update job template {{ integreatly_osd_install_name }} to set the extra vars to empty"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_osd_install_name }}\" --extra-vars '' "
+
 - name: "Update workflow stage {{ integreatly_job_template_deploy_name }}"
   shell: "tower-cli job_template modify -n \"{{ integreatly_osd_install_name }}\" --project integreatly-install-{{ integreatly_osd_install_branch }} --playbook playbooks/install.yml"
 

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_uninstall.yml
@@ -95,5 +95,10 @@
   retries: 10
   delay: 5
 
+# tower_job_template only allows a template YAML file to be provided when setting extra vars
+# Setting it to blank via tower-cli
+- name: "Update job template {{ integreatly_osd_uninstall_name }} to set the extra vars to empty"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_osd_uninstall_name }}\" --extra-vars '' "
+
 - name: "Update workflow stage {{ integreatly_job_template_uninstall_name }}"
   shell: "tower-cli job_template modify -n \"{{ integreatly_osd_uninstall_name }}\" --project integreatly-uninstall-{{ integreatly_osd_uninstall_branch }} --playbook playbooks/uninstall.yml"

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_update.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_update.yml
@@ -94,5 +94,10 @@
   retries: 10
   delay: 5
 
+# tower_job_template only allows a template YAML file to be provided when setting extra vars
+# Setting it to blank via tower-cli
+- name: "Update job template {{ integreatly_osd_upgrade_name }} to set the extra vars to empty"
+  shell: "tower-cli job_template modify -n \"{{ integreatly_osd_upgrade_name }}\" --extra-vars '' "
+
 - name: "Update workflow stage {{ integreatly_job_template_deploy_name }}"
   shell: "tower-cli job_template modify -n \"{{ integreatly_osd_upgrade_name }}\" --project integreatly-update-{{ integreatly_osd_update_branch }} --playbook playbooks/upgrades/upgrade.yaml"


### PR DESCRIPTION
Adding support for Ansible config OSD bootstrap playbooks to remove existing extra vars. These extra vars are no longer needed after 1.5.2 but the bootstrap process was not cleaning them up.

This has been tested against the CS SRE tower instance and it does remove the extra vars for the install, upgrade and uninstall OSD job templates. 