### PR TITLE
Updating Openshift Ansible repo tag

### DIFF
--- a/playbooks/roles/cluster/defaults/main.yml
+++ b/playbooks/roles/cluster/defaults/main.yml
@@ -14,7 +14,7 @@ cluster_project_bootstrap_cluster_scm_delete_on_update: true
 #                         #
 
 # openshift-ansible
-cluster_project_oa_bootstrap_scm_branch: "release-3.11"
+cluster_project_oa_bootstrap_scm_branch: "openshift-ansible-3.11.154-2"
 cluster_project_oa_bootstrap_scm_url: "git@github.com:openshift/openshift-ansible.git"
 
 #                            #


### PR DESCRIPTION
**Summary**
Updating the Openshift Ansible tag used for cluster deployments. This is currently pointing at a `release-3.11` branch which is subject to changes that can break Tower jobs.