### PR TITLE
adding github auth vars to enable tower specific github auth

### DIFF
--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -55,6 +55,13 @@ sre_prod_keys_credential_bundle_name: 'sre_prod_external_keys'
 sre_prod_keys_credential_bundle_type: "{{ custom_credential_bundle_external_keys_name }}"
 sre_prod_keys_credential_bundle_desc: 'Production External Services API Keys'
 
+# Ansible Tower GitHub Auth
+social_auth_github_org_name: '{{ lookup("vars", "_".join((tower_environment, "social_auth_github_org_name")) ) }}'
+social_auth_github_org_key: '{{ lookup("vars", "_".join((tower_environment, "social_auth_github_org_key")) ) }}'
+social_auth_github_org_secret: '{{ lookup("vars", "_".join((tower_environment, "social_auth_github_org_secret")) ) }}'
+social_auth_github_org_organization_map: '{{ lookup("vars", "_".join((tower_environment, "social_auth_github_org_organization_map")) ) }}'
+social_auth_github_org_team_map: '{{ lookup("vars", "_".join((tower_environment, "social_auth_github_org_team_map")) ) }}'
+
 # Ansible Tower Default Inventories
 tower_inventory_name: 'Default Tower Inventory'
 tower_inventory_desc: 'Default Tower Inventory used for local jobs'


### PR DESCRIPTION
This PR enables support for different github auth per tower instance. 

:warning: This most likely will break for anyone who does apply [these changes](https://github.com/integr8ly/tower_dummy_credentials/pull/15) to their credentials repo:warning: 

