### PR TITLE
bumped default poc version to 1.6.0

### DIFF
--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -8,7 +8,7 @@ cluster_aws_access_key: ''
 cluster_aws_secret_access_key: ''
 
 # Integreatly Configurations
-integreatly_version: 'release-1.5.2'
+integreatly_version: 'release-1.6.0'
 integreatly_install_type: 'poc'
 
 # Workflow Job Template


### PR DESCRIPTION
## What
bumped default poc version to 1.6.0 as per this trello card: https://trello.com/c/yNHWoHqA/32-update-tower-job-integreatly-install-pipeline-to-use-newly-released-version