### PR TITLE
create bootstrap job to specify credential for cluster provision

### DIFF
--- a/playbooks/cluster_provision_bootstrap.yml
+++ b/playbooks/cluster_provision_bootstrap.yml
@@ -1,0 +1,11 @@
+---
+- import_playbook: "./authenticate_tower.yml"
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_vars:
+        ./roles/tower/defaults/main.yml
+    - include_role:
+        name: cluster
+        tasks_from: cluster_provision_bootstrap.yml

--- a/playbooks/roles/cluster/defaults/main.yml
+++ b/playbooks/roles/cluster/defaults/main.yml
@@ -63,7 +63,12 @@ cluster_job_template_post_install_type: 'run'
 cluster_job_template_post_install_playbook: 'playbooks/cluster_create_post_install.yml'
 cluster_job_template_post_install_project: '{{ tower_configuration_project_name }}'
 
-cluster_workflow_job_template_name: "Cluster_provision_preflight"
+cluster_workflow_credential_job_template_name: "Cluster_provision_bootstrap"
+cluster_workflow_credential_job_template_desc: "Configure cluster provision workflow for a given cluster name"
+cluster_workflow_credential_job_template_playbook: "playbooks/cluster_provision_bootstrap.yml"
+
+cluster_workflow_job_template_name: "Cluster_provision"
+cluster_workflow_name: "Provision_workflow"
 cluster_workflow_job_template_desc: "Provision Openshift 3.11 cluster"
 
 cluster_workflow_job_template_openshift_auth: "Openshift_Authenticate_tower_pod"
@@ -71,8 +76,6 @@ cluster_workflow_job_template_openshift_auth: "Openshift_Authenticate_tower_pod"
 cluster_sync_job_name: "Configuration_project_sync"
 cluster_sync_job_desc: "A job to sync the ansible-tower-configuration repo"
 cluster_job_template_configuration_sync_playbook: "playbooks/configuration_project_sync.yml"
-
-cluster_workflow_name: "Provision_cluster"
 #                               #
 # Cluster deprovision templates #
 #                               #

--- a/playbooks/roles/cluster/defaults/main.yml
+++ b/playbooks/roles/cluster/defaults/main.yml
@@ -67,8 +67,8 @@ cluster_workflow_credential_job_template_name: "Cluster_provision_bootstrap"
 cluster_workflow_credential_job_template_desc: "Configure cluster provision workflow for a given cluster name"
 cluster_workflow_credential_job_template_playbook: "playbooks/cluster_provision_bootstrap.yml"
 
-cluster_workflow_job_template_name: "Cluster_provision"
-cluster_workflow_name: "Provision_workflow"
+cluster_workflow_job_template_name: "Cluster_provision_preflight"
+cluster_workflow_name: "Cluster_provision"
 cluster_workflow_job_template_desc: "Provision Openshift 3.11 cluster"
 
 cluster_workflow_job_template_openshift_auth: "Openshift_Authenticate_tower_pod"

--- a/playbooks/roles/cluster/tasks/bootstrap_cluster_create.yml
+++ b/playbooks/roles/cluster/tasks/bootstrap_cluster_create.yml
@@ -50,29 +50,6 @@
   command: tower-cli credential create --name "le_privatekey" --credential-type "le_privatekey" --inputs '{"le_key":"{{ letsencrypt_private_key }}"}' --organization "{{ tower_organization }}"
   ignore_errors: true
 
-- name: "Configure {{ cluster_workflow_job_template_name }} job template"
-  tower_job_template:
-    tower_host: "{{ tower_host }}"
-    tower_password: "{{ tower_password }}"
-    tower_username: "{{ tower_username }}"
-    name: "{{ cluster_workflow_job_template_name }}"
-    description: "{{ cluster_job_template_cluster_provision_desc }}"
-    job_type: "{{ cluster_job_template_cluster_provision_type }}"
-    playbook: "{{ cluster_job_template_cluster_provision_playbook }}"
-    project: "{{ cluster_job_template_cluster_provision_project }}"
-    credential: "{{ tower_credential_bundle_default_name }}"
-    state: present
-    inventory: "{{ tower_inventory_name }}"
-    tower_verify_ssl: '{{ tower_verify_ssl }}'
-    vault_credential: "{{ tower_credential_bundle_vault_name }}"
-    extra_vars_path: "{{ tower_extra_vars_file_path }}"
-    survey_enabled: yes
-    concurrent_jobs_enabled: yes
-  register: cluster_create_prerequisites_out
-  until: cluster_create_prerequisites_out is succeeded
-  retries: 10
-  delay: 5
-
 - name: "Configure {{ cluster_sync_job_name }} job template"
   tower_job_template:
     tower_host: "{{ tower_host }}"
@@ -94,8 +71,26 @@
   retries: 10
   delay: 5
 
-- debug:
-    msg: "{{ playbook_dir }}"
+- name: "Configure {{ cluster_workflow_credential_job_template_name }} job template"
+  tower_job_template:
+    tower_host: "{{ tower_host }}"
+    tower_password: "{{ tower_password }}"
+    tower_username: "{{ tower_username }}"
+    name: "{{ cluster_workflow_credential_job_template_name }}"
+    description: "{{ cluster_workflow_credential_job_template_desc }}"
+    job_type: "{{ cluster_job_template_cluster_provision_type }}"
+    playbook: "{{ cluster_workflow_credential_job_template_playbook }}"
+    project: "{{ cluster_job_template_cluster_provision_project }}"
+    vault_credential: "{{ tower_credential_bundle_vault_name }}"
+    state: present
+    inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+    extra_vars_path: "{{ tower_extra_vars_file_path }}"
+    concurrent_jobs_enabled: yes
+  register: cluster_create_preflight_out
+  until: cluster_create_preflight_out is succeeded
+  retries: 10
+  delay: 5
 
 - name: "Create workflow: {{ cluster_job_template_cluster_provision_name }}"
   tower_workflow_template:
@@ -111,8 +106,33 @@
     allow_simultaneous: yes
   register: create_workflow_response
 
+- name: Retrieve AWS Credential Type ID
+  shell: "tower-cli credential_type list --kind cloud -n \"Amazon Web Services\" -f id"
+  register: aws_cred_type_id
+
+- name: Retrieve list of AWS Credential Bundles
+  shell: "tower-cli credential list --credential-type {{ aws_cred_type_id.stdout }} -f json"
+  register: aws_credentials_raw
+  no_log: true
+
+- set_fact:
+    aws_credentials_json: "{{ aws_credentials_raw.stdout | from_json }}"
+    cluster_aws_accounts: []
+
+- name: "Set list of Integreatly AWS Accounts"
+  set_fact:
+    cluster_aws_accounts: "{{ cluster_aws_accounts + [ item.name ] }}"
+  with_items: "{{ aws_credentials_json.results }}"
+
+- set_fact:
+    cluster_install_survey_aws_accounts: "{{ cluster_aws_accounts | join('\\n')}}"
+
+- template:
+    src: roles/cluster/templates/cluster_provision_survey.json.j2
+    dest: /tmp/cluster_provision_survey.json
+
 - name: Update provision workflow template with survey
-  shell: "tower-cli workflow modify --name=\"{{ cluster_job_template_cluster_provision_name }}\" --survey-enabled=true --survey-spec='@roles/cluster/files/cluster_provision_survey.json'"
+  shell: "tower-cli workflow modify --name=\"{{ cluster_job_template_cluster_provision_name }}\" --survey-enabled=true --survey-spec='@/tmp/cluster_provision_survey.json'"
 
 - name: create workflow
   template:
@@ -121,12 +141,6 @@
 
 - name: Update provision workflow template with schema
   shell: "tower-cli workflow schema \"{{ cluster_job_template_cluster_provision_name }}\" @/tmp/provision_cluster_workflow.yml"
-
-- name: "Associate AWS credential to {{ cluster_workflow_job_template_name }}"
-  shell: tower-cli job_template associate_credential --job-template "{{ cluster_workflow_job_template_name }}" --credential "{{ cluster_credential_bundle_aws_name }}"
-
-- name: "Associate le_privatekey credential to {{ cluster_workflow_job_template_name }}"
-  shell: tower-cli job_template associate_credential --job-template "{{ cluster_workflow_job_template_name }}" --credential "le_privatekey"
 
 - include_role:
     name: tower

--- a/playbooks/roles/cluster/tasks/cluster_provision_bootstrap.yml
+++ b/playbooks/roles/cluster/tasks/cluster_provision_bootstrap.yml
@@ -1,0 +1,143 @@
+---
+#
+# Generate and launch workflow for cluster create
+#
+- name: Create temp directory
+  file:
+    path: /tmp/{{ oo_clusterid }}/certs
+    state: directory
+    recurse: yes
+
+- name: Create variables file
+  template:
+    src: inventory_template.yml.j2
+    dest: /tmp/{{ oo_clusterid }}/inventory_placeholder.yml
+
+- name: Create cluster inventory in tower
+  shell: tower-cli inventory create -n {{ oo_clusterid }} --organization secret
+
+- name: "Configure {{ cluster_workflow_job_template_name }} job template"
+  tower_job_template:
+    tower_host: "{{ tower_host }}"
+    tower_password: "{{ tower_password }}"
+    tower_username: "{{ tower_username }}"
+    name: "{{ cluster_workflow_job_template_name }}-{{ oo_clusterid }}"
+    description: "{{ cluster_job_template_cluster_provision_desc }}"
+    job_type: "{{ cluster_job_template_cluster_provision_type }}"
+    playbook: "{{ cluster_job_template_cluster_provision_playbook }}"
+    project: "{{ cluster_job_template_cluster_provision_project }}"
+    credential: "{{ tower_credential_bundle_default_name }}"
+    state: present
+    inventory: "{{ tower_inventory_name }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+    vault_credential: "{{ tower_credential_bundle_vault_name }}"
+    extra_vars_path: "/tmp/{{ oo_clusterid }}/inventory_placeholder.yml"
+    survey_enabled: yes
+    concurrent_jobs_enabled: yes
+  register: cluster_create_prerequisites_out
+  until: cluster_create_prerequisites_out is succeeded
+  retries: 3
+  delay: 5
+
+- name: "Associate {{ cluster_inventory_source_aws_credentials }} credential to {{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}"
+  shell: tower-cli job_template associate_credential --job-template "{{ cluster_workflow_job_template_name }}-{{ oo_clusterid }}" --credential "{{ cluster_inventory_source_aws_credentials }}" {% if not tower_verify_ssl  %}--insecure{% endif %}
+
+- name: "Associate le_privatekey credential to {{ cluster_workflow_job_template_name }}"
+  shell: tower-cli job_template associate_credential --job-template "{{ cluster_workflow_job_template_name }}-{{ oo_clusterid }}" --credential "le_privatekey"
+
+- name: Configure prerequisites job template
+  tower_job_template:
+    name: "{{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}"
+    description: "{{ cluster_job_template_prerequisites_desc }}"
+    job_type: "{{ cluster_job_template_prerequisites_type }}"
+    playbook: "{{ cluster_job_template_prerequisites_playbook }}"
+    project: "{{ cluster_job_template_prerequisites_project }}"
+    credential: "{{ tower_credential_bundle_default_name }}"
+    extra_vars_path: "/tmp/{{ oo_clusterid }}/inventory_placeholder.yml"
+    state: present
+    inventory: "{{ oo_clusterid }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: cluster_create_prerequisites_out
+  until: cluster_create_prerequisites_out is succeeded
+  retries: 10
+  delay: 5
+
+- name: "Associate {{ cluster_inventory_source_aws_credentials }} credential to {{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}"
+  shell: tower-cli job_template associate_credential --job-template "{{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}" --credential "{{ cluster_inventory_source_aws_credentials }}" {% if not tower_verify_ssl  %}--insecure{% endif %}
+
+- name: Configure provision install job template
+  tower_job_template:
+    name: "{{ cluster_job_template_install_name }}-{{ oo_clusterid }}"
+    description: "{{ cluster_job_template_install_desc }}"
+    job_type: "{{ cluster_job_template_install_type }}"
+    playbook: "{{ cluster_job_template_install_playbook }}"
+    project: "{{ cluster_job_template_install_project }}"
+    credential: "{{ tower_credential_bundle_default_name }}"
+    extra_vars_path: "/tmp/{{ oo_clusterid }}/inventory_placeholder.yml"
+    state: present
+    inventory: "{{ oo_clusterid }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: cluster_create_provision_install_out
+  until: cluster_create_provision_install_out is succeeded
+  retries: 10
+  delay: 5
+
+- name: "Associate {{ cluster_inventory_source_aws_credentials }} credentials {{ cluster_job_template_install_name }}-{{ oo_clusterid }}"
+  shell: tower-cli job_template associate_credential --job-template "{{ cluster_job_template_install_name }}-{{ oo_clusterid }}" --credential "{{ cluster_inventory_source_aws_credentials }}"  {% if not tower_verify_ssl %}--insecure{% endif %}
+
+- name: Configure post-install job template
+  tower_job_template:
+    name: "{{ cluster_job_template_post_install_name }}-{{ oo_clusterid }}"
+    description: "{{ cluster_job_template_post_install_desc }}"
+    job_type: "{{ cluster_job_template_post_install_type }}"
+    playbook: "{{ cluster_job_template_post_install_playbook }}"
+    project: "{{ cluster_job_template_post_install_project }}"
+    credential: "{{ tower_credential_bundle_default_name }}"
+    state: present
+    inventory: "{{ oo_clusterid }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: cluster_create_post_install_out
+  until: cluster_create_post_install_out is succeeded
+  retries: 10
+  delay: 5
+
+- name: Set workflow name
+  set_fact:
+    provision_workflow_name: "{{ cluster_workflow_name }}_{{ oo_clusterid }}"
+
+- name: Create workflow schema
+  template:
+    src: workflow_schema.yml.j2
+    dest: "/tmp/cluster_workflow_schema_{{ oo_clusterid }}.yml"
+
+- name: "Create workflow: {{ cluster_workflow_name }}_{{ oo_clusterid }}"
+  tower_workflow_template:
+    name:  "{{ provision_workflow_name}}"
+    schema: "{{ lookup('file', '/tmp/cluster_workflow_schema_{{ oo_clusterid }}.yml' ) }}"
+    description: "{{ cluster_workflow_job_template_desc }}"
+    state: present
+    organization: "{{ tower_organization }}"
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+  register: create_workflow_response
+
+- name: Clean up files
+  file:
+    path: cluster_workflow_schema.yml
+    state: absent
+
+- name: "Sync project: {{ cluster_job_template_prerequisites_project }}"
+  shell: tower-cli project update -n "{{ cluster_job_template_prerequisites_project }}" {% if not tower_verify_ssl  %}--insecure{% endif %}
+  register: oa_project_update
+  retries: 10
+  delay: 3
+  until: oa_project_update.rc == 0
+
+- name: "Launch cluster-provision for {{ oo_clusterid }}"
+  shell: tower-cli workflow_job launch --workflow-job-template "{{ provision_workflow_name }}" {% if not tower_verify_ssl  %}--insecure{% endif %}
+
+- name: "Retrieve generated workflow ID"
+  shell: tower-cli workflow_job list --workflow-job-template "{{ provision_workflow_name }}" --status running -f id {% if not tower_verify_ssl  %}--insecure{% endif %} | awk {'print $NF'}
+  register: provision_workflow_id
+
+- name: "Waiting for cluster workflow job to complete: {{ provision_workflow_name }}"
+  shell: tower-cli workflow_job wait {{ provision_workflow_id.stdout }} {% if not tower_verify_ssl  %}--insecure{% endif %}

--- a/playbooks/roles/cluster/tasks/provision_cluster.yml
+++ b/playbooks/roles/cluster/tasks/provision_cluster.yml
@@ -32,21 +32,17 @@
   - name: set domain variable
     set_fact:
       domain: "{% if cluster_type=='dev' %}{{ dev_domain }}{% elif cluster_type=='poc' %}{{ poc_domain }}{% endif %}"
+    when: dns_domain == ""
+
+  - name: set domain variable if passed through survey
+    set_fact:
+      domain: "{{ dns_domain }}"
+    when: dns_domain != ""
 
   - name: Set cluster urls
     set_fact:
       base_cluster_url: "{{ oo_clusterid }}.{{ domain }}"
       apps_cluster_url: "apps.{{ oo_clusterid }}.{{ domain }}"
-
-  - name: set 3scale wildcard URL
-    set_fact:
-      scale_wildcard_url: "amp.{{ oo_clusterid }}.{{ domain }}"
-
-  - name: Create temp directory
-    file:
-      path: /tmp/{{ oo_clusterid }}/certs
-      state: directory
-      recurse: yes
 
   - name: Ensure the cert bucket exists
     aws_s3:
@@ -123,30 +119,6 @@
     when: rootca_result.stat.exists == false
 
   #
-  # Check locally for amp.CLUSTERNAME.DOMAIN cert. If you can't find it then check S3
-  #
-  - stat: path=/tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt
-    register: scale_crt_result
-
-  - name: Check S3 for 3scale cert and key
-    block:
-    - name: Check for cert
-      aws_s3:
-        bucket: "{{ cluster_backup_bucket_name }}"
-        object: certs/{{ oo_clusterid }}/wildcard.{{ scale_wildcard_url }}.crt
-        dest: /tmp/{{ oo_clusterid }}/wildcard.{{ scale_wildcard_url }}.crt
-        mode: get
-      register: scale_crt_result_s3
-    - name: Check for key
-      aws_s3:
-        bucket: "{{ cluster_backup_bucket_name }}"
-        object: certs/{{ oo_clusterid }}/wildcard.{{ scale_wildcard_url }}.key
-        dest: /tmp/{{ oo_clusterid }}/wildcard.{{ scale_wildcard_url }}.key
-        mode: get
-    ignore_errors: true
-    when: scale_crt_result.stat.exists == false
-
-  #
   # LetsEncrypt cert generation
   #
   - name: Make sure account exists and has given contacts. We agree to TOS.
@@ -157,7 +129,7 @@
         acme_version: 2
         acme_directory: "{{ acme_directory_url }}"
         contact:
-        - mailto:integreatly-notifications@redhat.com
+        - mailto: "{{ cert_email_address }}"
 
   - name: Create directory for certs
     file:
@@ -185,17 +157,6 @@
           common_name: "{{ apps_cluster_url }}"
           subject_alt_name: 'DNS:{{ apps_cluster_url }},DNS:*.{{ apps_cluster_url }}'
     when: app_crt_result.stat.exists == false and app_crt_result_s3.failed == true
-
-  - name: Generate a private key and csr for the 3scale wildcard cert
-    block:
-      - openssl_privatekey:
-          path: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.key
-      - openssl_csr:
-          privatekey_path: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.key
-          path: "/tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.csr"
-          common_name: "{{ scale_wildcard_url }}"
-          subject_alt_name: 'DNS:{{ scale_wildcard_url }},DNS:*.{{ scale_wildcard_url }}'
-    when: scale_crt_result.stat.exists == false and scale_crt_result_s3.failed == true
 
   # Generate <clustername>.<domain> certs
   - name: Generate "{{ oo_clusterid }}"."{{ domain }}" cert
@@ -301,74 +262,9 @@
           overwrite: true
     when: app_crt_result.stat.exists == false and app_crt_result_s3.failed == true
 
-  # Generate 3scale-wildcard cert
-  - name: Generate "{{ scale_wildcard_url }}" cert
-    block:
-      - acme_certificate:
-          account_key_content: "{{ letsencrypt_private_key }}"
-          account_email: "integreatly-notifications@redhat.com"
-          acme_version: 2
-          src: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.csr
-          dest: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt
-          challenge: dns-01
-          acme_directory: "{{ acme_directory_url }}"
-        register: scale_wildcard_challenge
-      - set_fact:
-          challenges:
-          - "{{ scale_wildcard_challenge.challenge_data[scale_wildcard_url]['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
-          - "{{ scale_wildcard_challenge.challenge_data['*.' + scale_wildcard_url]['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
-      - set_fact:
-          scale_wildcard_dns_challenge: "{{ challenges | join(',') }}"
-      - route53:
-          zone: "{{ domain }}"
-          record: "{{ scale_wildcard_challenge.challenge_data[scale_wildcard_url]['dns-01'].record }}"
-          type: TXT
-          ttl: 60
-          state: present
-          value: "{{ scale_wildcard_dns_challenge }}"
-          aws_access_key: "{{ dns_access_key | default(aws_access_key) }}"
-          aws_secret_key: "{{ dns_secret_key | default(aws_secret_key) }}"
-          wait: yes
-        when: scale_wildcard_challenge is changed
-      - acme_certificate:
-          account_key_content: "{{ letsencrypt_private_key }}"
-          account_email: "integreatly-notifications@redhat.com"
-          acme_version: 2
-          src: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.csr
-          cert: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt
-          chain: /tmp/{{ oo_clusterid }}/certs/scale-rootCA.pem
-          challenge: dns-01
-          acme_directory: "{{ acme_directory_url }}"
-          remaining_days: 60
-          data: "{{ scale_wildcard_challenge }}"
-      - route53:
-          zone: "{{ domain }}"
-          record: "{{ scale_wildcard_challenge.challenge_data[scale_wildcard_url]['dns-01'].record }}"
-          value: "{{ scale_wildcard_dns_challenge }}"
-          type: TXT
-          ttl: 60
-          state: absent
-          aws_access_key: "{{ dns_access_key | default(aws_access_key) }}"
-          aws_secret_key: "{{ dns_secret_key | default(aws_secret_key) }}"
-          overwrite: true
-    when: scale_crt_result.stat.exists == false and cluster_type == 'poc' and scale_crt_result_s3.failed == true
-
   #
-  # Setup backups and generate 3scale route json file
+  # Setup backups
   #
-  - name: Get 3scale wildcard cert contents
-    set_fact:
-      scale_wildcard_ca_certificate_content: "{{ lookup('file', '/tmp/{{ oo_clusterid }}/certs/scale-rootCA.pem') }}"
-      scale_wildcard_certificate_content: "{{ lookup('file', '/tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt') }}"
-      scale_wildcard_private_key_content: "{{ lookup('file', '/tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.key') }}"
-    when: cluster_type == 'poc'
-
-  - name: Generate 3scale wildcard route template
-    template:
-      src: files/3scale-wildcard.json.j2
-      dest: /tmp/{{ oo_clusterid }}/3scale-wildcard-route.json
-    when: cluster_type == 'poc'
-
   - name: Create a bucket for integreatly backups
     aws_s3:
       aws_access_key: "{{ aws_access_key }}"
@@ -391,16 +287,6 @@
       - "wildcard.{{ base_cluster_url }}.crt"
       - "rootCA.pem"
 
-  - name: Backup 3scale cert to bucket if it exists
-    aws_s3:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      bucket: "{{ cluster_backup_bucket_name }}"
-      object: /certs/{{ oo_clusterid }}/wildcard.{{ scale_wildcard_url }}.crt
-      src: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.crt
-      mode: put
-    when: cluster_type == 'poc'
-
   - name: Backup keys to bucket
     aws_s3:
       aws_access_key: "{{ aws_access_key }}"
@@ -412,16 +298,6 @@
     with_items:
       - "{{ apps_cluster_url }}"
       - "{{ base_cluster_url }}"
-
-  - name: Backup 3scale key to bucket if it exists
-    aws_s3:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      bucket: "{{ cluster_backup_bucket_name }}"
-      object: /certs/{{ oo_clusterid }}/wildcard.{{ scale_wildcard_url }}.key
-      src: /tmp/{{ oo_clusterid }}/certs/wildcard.{{ scale_wildcard_url }}.key
-      mode: put
-    when: cluster_type == 'poc'
 
   #
   # Prerequisites for openshift-ansible
@@ -471,106 +347,4 @@
       state: absent
 
   - name: Create cluster inventory in tower
-    shell: tower-cli inventory create -n {{ oo_clusterid }} --variables @/tmp/{{ oo_clusterid }}/{{ oo_clusterid }}_inventory.yml --organization secret {% if not tower_verify_ssl %}--insecure{% endif %}
-
-  #
-  # Generate and launch workflow for cluster create
-  #
-  - name: Configure prerequisites job template
-    tower_job_template:
-      name: "{{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}"
-      description: "{{ cluster_job_template_prerequisites_desc }}"
-      job_type: "{{ cluster_job_template_prerequisites_type }}"
-      playbook: "{{ cluster_job_template_prerequisites_playbook }}"
-      project: "{{ cluster_job_template_prerequisites_project }}"
-      credential: "{{ tower_credential_bundle_default_name }}"
-      state: present
-      inventory: "{{ oo_clusterid }}"
-      tower_verify_ssl: '{{ tower_verify_ssl }}'
-    register: cluster_create_prerequisites_out
-    until: cluster_create_prerequisites_out is succeeded
-    retries: 10
-    delay: 5
-
-  - name: "Associate {{ cluster_job_template_prerequisites_credentials }} credential to {{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}"
-    shell: tower-cli job_template associate_credential --job-template "{{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}" --credential "{{ cluster_job_template_prerequisites_credentials }}" {% if not tower_verify_ssl  %}--insecure{% endif %}
-
-  - name: Configure provision install job template
-    tower_job_template:
-
-      name: "{{ cluster_job_template_install_name }}-{{ oo_clusterid }}"
-      description: "{{ cluster_job_template_install_desc }}"
-      job_type: "{{ cluster_job_template_install_type }}"
-      playbook: "{{ cluster_job_template_install_playbook }}"
-      project: "{{ cluster_job_template_install_project }}"
-      credential: "{{ tower_credential_bundle_default_name }}"
-      state: present
-      inventory: "{{ oo_clusterid }}"
-      tower_verify_ssl: '{{ tower_verify_ssl }}'
-    register: cluster_create_provision_install_out
-    until: cluster_create_provision_install_out is succeeded
-    retries: 10
-    delay: 5
-
-  - name: "Associate {{ cluster_credential_bundle_aws_name }} credentials {{ cluster_job_template_install_name }}-{{ oo_clusterid }}"
-    shell: tower-cli job_template associate_credential --job-template "{{ cluster_job_template_install_name }}-{{ oo_clusterid }}" --credential "{{ cluster_credential_bundle_aws_name }}"  {% if not tower_verify_ssl %}--insecure{% endif %}
-
-  - name: "Associate {{ cluster_job_template_install_credentials }} credential to {{ cluster_job_template_install_name }}-{{ oo_clusterid }}"
-    shell: tower-cli job_template associate_credential --job-template "{{ cluster_job_template_install_name }}-{{ oo_clusterid }}" --credential "{{ cluster_job_template_install_credentials }}"  {% if not tower_verify_ssl  %}--insecure{% endif %}
-
-  - name: Configure post-install job template
-    tower_job_template:
-      name: "{{ cluster_job_template_post_install_name }}-{{ oo_clusterid }}"
-      description: "{{ cluster_job_template_post_install_desc }}"
-      job_type: "{{ cluster_job_template_post_install_type }}"
-      playbook: "{{ cluster_job_template_post_install_playbook }}"
-      project: "{{ cluster_job_template_post_install_project }}"
-      credential: "{{ tower_credential_bundle_default_name }}"
-      state: present
-      inventory: "{{ oo_clusterid }}"
-      tower_verify_ssl: '{{ tower_verify_ssl }}'
-    register: cluster_create_post_install_out
-    until: cluster_create_post_install_out is succeeded
-    retries: 10
-    delay: 5
-
-  - name: Set workflow name
-    set_fact:
-      provision_workflow_name: "{{ cluster_workflow_job_template_name }}_{{ oo_clusterid }}"
-
-  - name: Create workflow schema
-    template:
-      src: workflow_schema.yml.j2
-      dest: "/tmp/cluster_workflow_schema_{{ oo_clusterid }}.yml"
-
-  - name: "Create workflow: {{ cluster_workflow_job_template_name }}_{{ oo_clusterid }}"
-    tower_workflow_template:
-      name:  "{{ provision_workflow_name}}"
-      schema: "{{ lookup('file', '/tmp/cluster_workflow_schema_{{ oo_clusterid }}.yml' ) }}"
-      description: "{{ cluster_workflow_job_template_desc }}"
-      state: present
-      organization: "{{ tower_organization }}"
-      tower_verify_ssl: '{{ tower_verify_ssl }}'
-    register: create_workflow_response
-
-  - name: Clean up files
-    file:
-      path: cluster_workflow_schema.yml
-      state: absent
-
-  - name: "Sync project: {{ cluster_job_template_prerequisites_project }}"
-    shell: tower-cli project update -n "{{ cluster_job_template_prerequisites_project }}" {% if not tower_verify_ssl  %}--insecure{% endif %}
-    register: oa_project_update
-    retries: 10
-    delay: 3
-    until: oa_project_update.rc == 0
-
-  - name: "Launch cluster-provision for {{ oo_clusterid }}"
-    shell: tower-cli workflow_job launch --workflow-job-template "{{ provision_workflow_name }}" {% if not tower_verify_ssl  %}--insecure{% endif %}
-
-  - name: "Retrieve generated workflow ID"
-    shell: tower-cli workflow_job list --workflow-job-template "{{ provision_workflow_name }}" --status running -f id {% if not tower_verify_ssl  %}--insecure{% endif %} | awk {'print $NF'}
-    register: provision_workflow_id
-
-  - name: "Waiting for cluster workflow job to complete: {{ provision_workflow_name }}"
-    shell: tower-cli workflow_job wait {{ provision_workflow_id.stdout }} {% if not tower_verify_ssl  %}--insecure{% endif %}
+    shell: tower-cli inventory modify -n {{ oo_clusterid }} --variables @/tmp/{{ oo_clusterid }}/{{ oo_clusterid }}_inventory.yml {% if not tower_verify_ssl %}--insecure{% endif %}

--- a/playbooks/roles/cluster/tasks/remove_dns_records.yml
+++ b/playbooks/roles/cluster/tasks/remove_dns_records.yml
@@ -1,6 +1,6 @@
 - route53: 
-    aws_access_key: "{{ aws_access_key }}"
-    aws_secret_key: "{{ aws_secret_key }}"
+    aws_access_key: "{{ dns_access_key | default(aws_access_key) }}"
+    aws_secret_key: "{{ dns_secret_key | default(aws_secret_key) }}"
     record: "{{ record }}"
     state: get
     type: CNAME
@@ -11,8 +11,8 @@
     aws_dns_record: "{{ get_aws_dns_record.set }}"
 
 - route53:
-    aws_access_key: "{{ aws_access_key }}"
-    aws_secret_key: "{{ aws_secret_key }}"
+    aws_access_key: "{{ dns_access_key | default(aws_access_key) }}"
+    aws_secret_key: "{{ dns_secret_key | default(aws_secret_key) }}"
     record: "{{ aws_dns_record.record }}"
     state: absent
     ttl: "{{ aws_dns_record.ttl }}"

--- a/playbooks/roles/cluster/tasks/workflow.yml
+++ b/playbooks/roles/cluster/tasks/workflow.yml
@@ -26,9 +26,9 @@
 - name: "Associate le_privatekey credential to {{ cluster_job_template_cluster_provision_name }}" 
   shell: tower-cli job_template associate_credential --job-template "{{ cluster_job_template_cluster_provision_name }}" --credential "le_privatekey"
 
-- name: "Create workflow: {{ cluster_workflow_job_template_name }}"
+- name: "Create workflow: {{ cluster_workflow_name }}"
   tower_workflow_template:
-    name:  "{{ cluster_workflow_job_template_name }}"
+    name:  "{{ cluster_workflow_name }}"
     description: "{{ cluster_workflow_job_template_desc }}"
     state: present
     organization: "{{ tower_organization }}"

--- a/playbooks/roles/cluster/templates/cluster_provision_survey.json.j2
+++ b/playbooks/roles/cluster/templates/cluster_provision_survey.json.j2
@@ -37,6 +37,18 @@
       "type": "multiplechoice"
       },
       {
+        "question_description": "AWS Account Credentials",
+        "min": null,
+        "default": "",
+        "max": null,
+        "required": true,
+        "choices": "{{ cluster_install_survey_aws_accounts }}",
+        "new_question": true,
+        "variable": "cluster_inventory_source_aws_credentials",
+        "question_name": "AWS Credentials",
+        "type": "multiplechoice"
+      },
+      {
         "question_description": "Number of master nodes required",
         "min": 1,
         "default": 3,
@@ -68,6 +80,34 @@
         "variable": "openshift_aws_compute_group_desired_size",
         "question_name": "Compute Nodes",
         "type": "integer"
-      }   
+      },
+      {
+        "question_description": "Optional - Cluster domain if different from default",
+        "default": "",
+        "required": false,
+        "choices": "",
+        "variable": "dns_domain",
+        "question_name": "Domain",
+        "type": "text"
+      },
+      {
+        "question_description": "Optional - AWS access key for DNS access",
+        "default": "",
+        "required": false,
+        "choices": "",
+        "variable": "dns_access_key",
+        "question_name": "DNS Access Key",
+        "type": "text"
+      },
+      {
+        "question_description": "Optional - AWS secret access key for DNS access",
+        "default": "",
+        "required": false,
+        "choices": "",
+        "new_question": true,
+        "variable": "dns_secret_key",
+        "question_name": "DNS Secret Key",
+        "type": "password"
+      }
     ]
   }

--- a/playbooks/roles/cluster/templates/cluster_teardown_workflow_survey.json.j2
+++ b/playbooks/roles/cluster/templates/cluster_teardown_workflow_survey.json.j2
@@ -45,6 +45,25 @@
       "variable": "cluster_credential_bundle_aws_name",
       "question_name": "AWS account name",
       "type": "multiplechoice"
+    },
+    {
+      "question_description": "Optional - AWS access key for DNS access",
+      "default": "",
+      "required": false,
+      "choices": "",
+      "variable": "dns_access_key",
+      "question_name": "DNS Access Key",
+      "type": "text"
+    },
+    {
+      "question_description": "Optional - AWS secret access key for DNS access",
+      "default": "",
+      "required": false,
+      "choices": "",
+      "new_question": true,
+      "variable": "dns_secret_key",
+      "question_name": "DNS Secret Key",
+      "type": "password"
     }
   ]
 }

--- a/playbooks/roles/cluster/templates/inventory_template.yml.j2
+++ b/playbooks/roles/cluster/templates/inventory_template.yml.j2
@@ -1,0 +1,16 @@
+---
+oo_clusterid: "{{ oo_clusterid }}"
+oo_sublocation: "{{ oo_sublocation }}"
+survey_provision_logging: "{{ survey_provision_logging }}"
+cluster_inventory_source_aws_credentials: "{{ cluster_inventory_source_aws_credentials }}"
+openshift_aws_master_group_desired_size: "{{ openshift_aws_master_group_desired_size }}"
+openshift_aws_infra_group_desired_size: "{{ openshift_aws_infra_group_desired_size }}"
+openshift_aws_compute_group_desired_size: "{{ openshift_aws_compute_group_desired_size }}"
+tower_environment: "{{ tower_environment }}"
+dns_domain: "{{ dns_domain }}"
+{% if dns_access_key != "" %}
+dns_access_key: "{{ dns_access_key }}"
+{% endif %}
+{% if dns_secret_key != "" %}
+dns_secret_key: "{{ dns_secret_key }}"
+{% endif %}

--- a/playbooks/roles/cluster/templates/provision_cluster_workflow.yml.j2
+++ b/playbooks/roles/cluster/templates/provision_cluster_workflow.yml.j2
@@ -1,4 +1,4 @@
 ---
 - job_template: "{{ cluster_sync_job_name }}"
   success:
-  - job_template: "{{ cluster_workflow_job_template_name }}"
+  - job_template: "{{ cluster_workflow_credential_job_template_name }}"

--- a/playbooks/roles/cluster/templates/workflow_schema.yml.j2
+++ b/playbooks/roles/cluster/templates/workflow_schema.yml.j2
@@ -1,10 +1,12 @@
 ---
-- job_template: "{{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}"
+- job_template: "{{ cluster_workflow_job_template_name }}-{{ oo_clusterid }}"
   success:
-  - job_template: "{{ cluster_job_template_install_name }}-{{ oo_clusterid }}"
+  - job_template: "{{ cluster_job_template_prerequisites_name }}-{{ oo_clusterid }}"
     success:
-    - job_template: "{{ cluster_job_template_post_install_name }}-{{ oo_clusterid }}"
-    failure:
     - job_template: "{{ cluster_job_template_install_name }}-{{ oo_clusterid }}"
       success:
-        - job_template: "{{ cluster_job_template_post_install_name }}-{{ oo_clusterid }}"
+      - job_template: "{{ cluster_job_template_post_install_name }}-{{ oo_clusterid }}"
+      failure:
+      - job_template: "{{ cluster_job_template_install_name }}-{{ oo_clusterid }}"
+        success:
+          - job_template: "{{ cluster_job_template_post_install_name }}-{{ oo_clusterid }}"

--- a/playbooks/roles/integreatly/files/osd_cve_rollout_survey.json
+++ b/playbooks/roles/integreatly/files/osd_cve_rollout_survey.json
@@ -56,7 +56,7 @@
         "required": false,
         "choices": "",
         "variable": "integreatly_osd_cve_rollout_product_tags",
-        "question_name": "Product Specific Tags [Optional]",
+        "question_name": "Optional - Product Specific Tags",
         "type": "text"
       }
     ]


### PR DESCRIPTION
- Add cluster provision bootstrap to allow a user to pick AWS credentials for provision from a list
- Remove 3scale extra route and cert creation
- Make email address for letsencrypt configurable
- Allow setting domain in survey if hosted in a different account and provide keys for that account