### PR TITLE
make tower credential bundle name configurable

### DIFF
--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -25,7 +25,7 @@ tower_secret_organization: 'secret'
 tower_team: 'integreatly-eng'
 
 # Ansible Tower Credentials
-tower_credential_bundle_vault_name: 'integreatly_vault'
+tower_credential_bundle_vault_name: "{{ tower_credential_bundle_vault_name }}"
 tower_credential_bundle_vault_desc: 'Default Tower vault credential'
 tower_credential_bundle_vault_type: 'vault'
 

--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -25,7 +25,7 @@ tower_secret_organization: 'secret'
 tower_team: 'integreatly-eng'
 
 # Ansible Tower Credentials
-tower_credential_bundle_vault_name: "{{ tower_credential_bundle_vault_name }}"
+tower_credential_bundle_vault_name: "{{ tower_credential_vault_name }}"
 tower_credential_bundle_vault_desc: 'Default Tower vault credential'
 tower_credential_bundle_vault_type: 'vault'
 


### PR DESCRIPTION
This variable is already configurable in the dummy_tower_credential repo https://github.com/integr8ly/tower_dummy_credentials/blob/master/CREDENTIAL_CONFIG.yml#L38. So this change change is just to respect that variable here.