### PR TITLE
Intly 4282 Refactor bootstrapping

### DIFF
--- a/e2e_test_config.yml
+++ b/e2e_test_config.yml
@@ -72,21 +72,21 @@ cluster_credential_git_repo: "git@github.com:integr8ly/tower_dummy_credentials.g
 tower_github_scm_password: ''
 # This is a generic private key not used anywhere else. It's just for testing and doesn't belong to anyone.
 tower_github_scm: |
-    -----BEGIN RSA PRIVATE KEY-----
-    MIICWgIBAAKBgGaDr0n+wuZAWNVcWFQXmBW5y16BYuonTR1X4HKLNJuZRKwvIXUr
-    vpCQ51IORcC1Vc+UeaPaML7l5D2mcQcOnWrZ7A6mrdE1Nb4C6OCJ/pMzWf+s3Eqx
-    I8fj5jKtgec/v6o9SUxshV5HW7m7rt5tNhybUmKJQJXh4TXWE6A1stYFAgMBAAEC
-    gYApea+qvVL3OyN1tzXZV+5lI9Ve9/QgDiSJ8arSTPXM2jbJfwwHTtp7vNSKA1I/
-    RF5ibIzGORmtsm8kbjmehFA1jkd+I/3isyAmPww7vvhowy/tCmh/8L0J4sdD/eig
-    MYIuJnKavKUg7uE3n6d9vx1nOF6VzloZIhPqr3mYmhqTxQJBALAt91kQSMm+Fn0l
-    hBZN84dcCwkGWCesTb8ggD+BUFqrejDMqLSE0yHnXgaN0tmjCjS/rALZyMIdZgSM
-    XHRKTJcCQQCU9bptiz1kMGXFSa6pWbZ4kq19XYcpkwa2Fj2QoOYLZUXfWj835uxo
-    6XUyn13A01xXFqfDZH+rsWvlYEv0llnDAkAMdnP03O4JN2Un3SuG2GTNwnkVXlmG
-    FO47AvWPiHpCr7apFREqE+tLjq5cEFRGCP6D1Ls6SGWnNaUt1TAFGexpAkAn7Q1B
-    G1cjKY29qZg1MCSmgLobphv6Wrwrxh5OS7IdT9HAohHby/uFyz1siia47m4LsbjZ
-    uHA39uAypPL25e29AkAFewRAveiihSOmSu3qa97tA7Gqsmvyzd/oOyNSuxxEHWm3
-    vc7mjU2RfU/a+R2CmuzitD83vDr6J6tKxnfSJiQV
-    -----END RSA PRIVATE KEY-----
+  -----BEGIN RSA PRIVATE KEY-----
+  MIICWgIBAAKBgGaDr0n+wuZAWNVcWFQXmBW5y16BYuonTR1X4HKLNJuZRKwvIXUr
+  vpCQ51IORcC1Vc+UeaPaML7l5D2mcQcOnWrZ7A6mrdE1Nb4C6OCJ/pMzWf+s3Eqx
+  I8fj5jKtgec/v6o9SUxshV5HW7m7rt5tNhybUmKJQJXh4TXWE6A1stYFAgMBAAEC
+  gYApea+qvVL3OyN1tzXZV+5lI9Ve9/QgDiSJ8arSTPXM2jbJfwwHTtp7vNSKA1I/
+  RF5ibIzGORmtsm8kbjmehFA1jkd+I/3isyAmPww7vvhowy/tCmh/8L0J4sdD/eig
+  MYIuJnKavKUg7uE3n6d9vx1nOF6VzloZIhPqr3mYmhqTxQJBALAt91kQSMm+Fn0l
+  hBZN84dcCwkGWCesTb8ggD+BUFqrejDMqLSE0yHnXgaN0tmjCjS/rALZyMIdZgSM
+  XHRKTJcCQQCU9bptiz1kMGXFSa6pWbZ4kq19XYcpkwa2Fj2QoOYLZUXfWj835uxo
+  6XUyn13A01xXFqfDZH+rsWvlYEv0llnDAkAMdnP03O4JN2Un3SuG2GTNwnkVXlmG
+  FO47AvWPiHpCr7apFREqE+tLjq5cEFRGCP6D1Ls6SGWnNaUt1TAFGexpAkAn7Q1B
+  G1cjKY29qZg1MCSmgLobphv6Wrwrxh5OS7IdT9HAohHby/uFyz1siia47m4LsbjZ
+  uHA39uAypPL25e29AkAFewRAveiihSOmSu3qa97tA7Gqsmvyzd/oOyNSuxxEHWm3
+  vc7mjU2RfU/a+R2CmuzitD83vDr6J6tKxnfSJiQV
+  -----END RSA PRIVATE KEY-----
 
 # tower_ssh.yml
 tower_ssh_user: e2e-test
@@ -120,3 +120,13 @@ tower_instance_list:
 
 e2e_tower_host:
 e2e_tower_verify_ssl: False
+
+cicd: true
+integreatly_version: "master"
+
+integreatly_project_install_scm_url: "https://github.com/integr8ly/installation"
+integreatly_osd_project_install_scm_url: "https://github.com/integr8ly/installation"
+integreatly_osd_project_uninstall_scm_url: "https://github.com/integr8ly/installation"
+integreatly_osd_cve_rollout_project_scm_url: "https://github.com/integr8ly/installation"
+
+

--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -1,6 +1,35 @@
 ---
-- import_playbook: "./bootstrap_tower.yml"
-- import_playbook: "./bootstrap_integreatly.yml"
-- import_playbook: "./bootstrap_cluster_create.yml"
-- import_playbook: "./bootstrap_cluster_teardown.yml"
-- import_playbook: "./bootstrap_validation.yml"
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_vars:
+        ./roles/tower/defaults/main.yml
+
+    - name: "Confirmation prompt for bootstrapping master"
+      pause:
+        prompt: 'Please confirm you want to bootstrap tower with the master branch of configuration and credential repos (yes/no)'
+      register: master_bootstrap_prompt
+      when: not cicd and integreatly_version == "master"
+
+    - name: 'Check Confirmation'
+      fail:
+        msg: "Playbook run confirmation failed"
+      when: master_bootstrap_prompt is not skipped and not master_bootstrap_prompt.user_input|bool
+
+#
+# POC/DEV & OSD
+#
+- import_playbook: "./bootstrap_all_jobs.yml"
+  when: bootstrap_type == "all"
+
+#
+# POC/DEV
+#
+- import_playbook: "./bootstrap_poc_jobs.yml"
+  when: bootstrap_type == "poc"
+
+#
+# SRE
+#
+- import_playbook: "./bootstrap_sre_jobs.yml"
+  when: bootstrap_type == "sre"

--- a/playbooks/bootstrap_all_jobs.yml
+++ b/playbooks/bootstrap_all_jobs.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - debug:
+        msg:
+         - "#"
+         - "# Bootstrapping all jobs"
+         - "#"
+
+- import_playbook: "./bootstrap_tower.yml"
+- import_playbook: "./bootstrap_validation.yml"
+- import_playbook: "./bootstrap_integreatly.yml"
+- import_playbook: "./bootstrap_cluster_create.yml"
+- import_playbook: "./bootstrap_cluster_teardown.yml"
+- import_playbook: "./bootstrap_osd_integreatly_install.yml"

--- a/playbooks/bootstrap_poc_jobs.yml
+++ b/playbooks/bootstrap_poc_jobs.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - debug:
+        msg:
+         - "#"
+         - "# Bootstrapping POC jobs"
+         - "#"
+
+- import_playbook: "./bootstrap_tower.yml"
+- import_playbook: "./bootstrap_validation.yml"
+- import_playbook: "./bootstrap_integreatly.yml"
+- import_playbook: "./bootstrap_cluster_create.yml"
+- import_playbook: "./bootstrap_cluster_teardown.yml"

--- a/playbooks/bootstrap_sre_jobs.yml
+++ b/playbooks/bootstrap_sre_jobs.yml
@@ -1,0 +1,22 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - debug:
+        msg:
+         - "#"
+         - "# Bootstrapping SRE jobs"
+         - "#"
+
+- import_playbook: "./bootstrap_tower.yml"
+- import_playbook: "./bootstrap_validation.yml"
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - include_role:
+        name: integreatly
+        tasks_from: bootstrap_cssre.yml
+
+
+- import_playbook: "./bootstrap_osd_integreatly_install.yml"

--- a/playbooks/roles/integreatly/defaults/main.yml
+++ b/playbooks/roles/integreatly/defaults/main.yml
@@ -8,7 +8,6 @@ cluster_aws_access_key: ''
 cluster_aws_secret_access_key: ''
 
 # Integreatly Configurations
-integreatly_version: 'release-1.6.0'
 integreatly_install_type: 'poc'
 
 # Workflow Job Template

--- a/playbooks/roles/integreatly/tasks/bootstrap.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap.yml
@@ -13,7 +13,7 @@
 
 - name: Bootstrap CS SRE Projects and Workflows
   include_tasks: bootstrap_cssre.yml
-  when: tower_sre_extras
+  when: bootstrap_type == "sre"
 
 - include_tasks: workflow_install.yml
 - include_tasks: workflow_uninstall.yml

--- a/playbooks/roles/integreatly/tasks/bootstrap_osd_workflow.yml
+++ b/playbooks/roles/integreatly/tasks/bootstrap_osd_workflow.yml
@@ -10,6 +10,9 @@
     tower_verify_ssl: '{{ tower_verify_ssl }}'
     allow_simultaneous: "{{ integreatly_osd_install_workflow_job_concurrency }}"
   register: create_workflow_response
+  until: create_workflow_response is succeeded
+  retries: 10
+  delay: 5
 
 - name: Create install workflow schema
   template:

--- a/playbooks/roles/integreatly/templates/osd_workflow_install_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/osd_workflow_install_schema.yml.j2
@@ -1,6 +1,6 @@
 ---
 - job_template: "{{ integreatly_osd_bootstrap_name }}"
-{% if tower_sre_extras | d() | bool %}
+{% if bootstrap_type == "sre" %}
   success:
   - job_template: "{{ rhmi_ssh_tunnel_create_name }}"
     success:

--- a/playbooks/roles/integreatly/templates/osd_workflow_uninstall_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/osd_workflow_uninstall_schema.yml.j2
@@ -1,6 +1,6 @@
 ---
 - job_template: "{{ integreatly_osd_uninstall_bootstrap_name }}"
-{% if tower_sre_extras | d() | bool %}
+{% if bootstrap_type == "sre" %}
   success:
   - job_template: "{{ rhmi_ssh_tunnel_create_name }}"
     success:

--- a/playbooks/roles/integreatly/templates/osd_workflow_upgrade_schema.yml.j2
+++ b/playbooks/roles/integreatly/templates/osd_workflow_upgrade_schema.yml.j2
@@ -1,6 +1,6 @@
 ---
 - job_template: "{{ integreatly_osd_upgrade_bootstrap_name }}"
-{% if tower_sre_extras | d() | bool %}
+{% if bootstrap_type == "sre" %}
   success:
   - job_template: "{{ rhmi_ssh_tunnel_create_name }}"
     success:

--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -38,7 +38,6 @@ tower_credential_bundle_github_desc: "Default Tower Credential Bundle for Github
 tower_credential_bundle_github_type: 'scm'
 
 tower_credential_bundle_aws_type: "aws"
-aws_credential_list: []
 
 # Extra Credentials Required by CS SRE
 custom_credential_bundle_bastion_ssh_name: 'osd_bastion_ssh'

--- a/playbooks/roles/tower/defaults/main.yml
+++ b/playbooks/roles/tower/defaults/main.yml
@@ -10,7 +10,6 @@ tower_license: '{{ lookup("vars", "_".join((tower_environment, "tower_license"))
 tower_verify_ssl: '{{ lookup("vars", "_".join((tower_environment, "tower_verify_ssl")) ) }}'
 tower_extra_vars_file_path: '/tmp/tower_extra_vars.yml'
 tower_bootstrap_vars_file_path: '/tmp/tower_bootstrap_vars.yml'
-tower_sre_extras: False
 
 # Ansible Tower Openshift Configurations
 tower_openshift_username: ''
@@ -71,8 +70,8 @@ tower_inventory_desc: 'Default Tower Inventory used for local jobs'
 tower_configuration_project_name: 'Ansible Tower Configuration Project'
 tower_configuration_project_desc: 'Configuration project for Ansible Tower'
 tower_configuration_project_scm_type: git
-tower_configuration_project_scm_branch: 'master'
 tower_configuration_project_scm_clean: true
+tower_configuration_project_scm_branch: '{{ integreatly_version  }}'
 tower_configuration_project_scm_type_url: 'https://github.com/integr8ly/ansible-tower-configuration.git'
 tower_configuration_project_scm_update_on_launch: false
 tower_configuration_project_scm_delete_on_update: true
@@ -81,9 +80,8 @@ tower_configuration_project_scm_delete_on_update: true
 tower_credentials_project_name: 'Ansible Tower Credentials Project'
 tower_credentials_project_desc: 'Credentials project for Ansible Tower'
 tower_credentials_project_scm_type: git
-tower_credentials_project_scm_branch: 'master'
 tower_credentials_project_scm_clean: true
-tower_credentials_project_scm_type_url: ''
+tower_credentials_project_scm_branch: '{{ integreatly_version }}'
 tower_credentials_project_scm_update_on_launch: false
 tower_credentials_project_scm_delete_on_update: true
 
@@ -193,3 +191,7 @@ tower_email_notification_template_recipients: '{{ send_grid_email_recipients }}'
 tower_email_notification_template_host: '{{ send_grid_host }}'
 tower_email_notification_template_port: '{{ send_grid_port }}'
 
+bootstrap_type: '{{ bootstrap | default("all") }}'
+cicd: false
+
+integreatly_version: 'master'

--- a/playbooks/roles/tower/tasks/bootstrap.yml
+++ b/playbooks/roles/tower/tasks/bootstrap.yml
@@ -86,7 +86,8 @@
     value:
       - "/tmp"
     tower_verify_ssl: '{{ tower_verify_ssl }}'
+  when: bootstrap_type == "sre"
 
 # Import the cssre bootstrap task
 - include_tasks: bootstrap_cssre.yml
-  when: tower_sre_extras
+  when: bootstrap_type == "sre"

--- a/playbooks/roles/tower/tasks/bootstrap_schedules.yml
+++ b/playbooks/roles/tower/tasks/bootstrap_schedules.yml
@@ -5,7 +5,7 @@
 
 - set_fact:
     tower_job_schedule_bootstrap_tower_rule_enabled: True
-  when: tower_sre_extras 
+  when: bootstrap_type == "sre"
 
 - name: Create {{ tower_job_schedule_bootstrap_tower_name }} schedule
   shell: >

--- a/playbooks/roles/tower/templates/tower_bootstrap_vars.yml.j2
+++ b/playbooks/roles/tower/templates/tower_bootstrap_vars.yml.j2
@@ -1,6 +1,6 @@
 ---
 tower_environment: {{ tower_environment }}
-tower_sre_extras: {{ tower_sre_extras }}
+bootstrap_type: {{ bootstrap | default("all") }}
 tower_configuration_project_scm_branch: {{ tower_configuration_project_scm_branch }}
 tower_credentials_project_scm_branch: {{ tower_credentials_project_scm_branch }}
-integreatly_version: {{ integreatly_version }}
+integreatly_version: {{ integreatly_version  }}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -33,4 +33,6 @@ echo "Bootstrapping tower in openshift project: ${TOWER_OPENSHIFT_PROJECT}"
 ansible-playbook -i ./inventories/hosts \
 playbooks/bootstrap.yml \
 --extra-vars "@e2e_test_config.yml"
+bootstrap_exit_code=$?
+echo "Bootstrap playbook ansible exit code: $bootstrap_exit_code"
 


### PR DESCRIPTION
This also includes a change to force a user to specify a tag for the configuration repo.

To bootstrap:

```
ansible-playbook -i ../<CREDENTIAL_REPO>/inventories/hosts playbooks/bootstrap.yml -e tower_environment=<ENVIRONMENT> -e integreatly_version=release-1.6.0 -e bootstrap=<BOOTSTRAP-TYPE> --ask-vault-pass
```