### PR TITLE
Including integreatly vars on tower bootstrap run

### DIFF
--- a/playbooks/bootstrap_tower.yml
+++ b/playbooks/bootstrap_tower.yml
@@ -2,6 +2,8 @@
 - hosts: localhost
   gather_facts: no
   tasks:
+    - include_vars:
+        ./roles/integreatly/defaults/main.yml
     - include_role:
         name: tower
         tasks_from: bootstrap.yml


### PR DESCRIPTION
**Summary**
Tower bootstrap breaks when integreatly version is not specified:
```
TASK [tower : Generate template file tower_bootstrap_vars.yml] ************************************************************************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'integreatly_version' is undefined"}
```

This PR resolves the problem