### PR TITLE
Add field for customer admin password

### DIFF
--- a/playbooks/roles/integreatly/templates/workflow_install_survey.json.j2
+++ b/playbooks/roles/integreatly/templates/workflow_install_survey.json.j2
@@ -49,6 +49,18 @@
         "type": "password"
       },
       {
+        "question_description": "Password of customer admin user",
+        "min": 0,
+        "default": "",
+        "max": 32,
+        "required": true,
+        "choices": "",
+        "new_question": true,
+        "variable": "rhsso_evals_admin_password",
+        "question_name": "Customer Admin Password",
+        "type": "password"
+      },
+      {
         "question_description": "Integreatly Installer Git URL",
         "min": 0,
         "default": "https://github.com/integr8ly/installation.git",


### PR DESCRIPTION
## Description 

Update the POC survey to add a new optional field for the `customer-admin` password. This avoids the manual step in the POC SOP for logging in as `customer-admin/Password1` and changing the password.

Jira: https://issues.redhat.com/browse/INTLY-4573 
Doc change: https://github.com/RHCloudServices/integreatly-help/pull/379

## Verification 
### Install and bootstrap tower
- Provision an OCP3 workshop from RHPDS
- Clone the `integreatly_dev` cred repo locally: https://github.com/RHCloudServices/integreatly_dev 
- Clone this repo locally and check out my branch 
- From this repo, install and bootstrap tower: (all these commands should be run locally)
```sh
# Install tower 
ansible-playbook -i /home/dimitra/integreatly/integreatly_dev/inventories/hosts playbooks/install_tower.yml -e tower_openshift_master_url=https://master.dimitra-80f4.open.redhat.com -e tower_openshift_username=opentlc-mgr -e tower_openshift_password=r3dh4t1! -e tower_openshift_pg_pvc_size=10Gi --ask-vault-pass

# You might need to install the ansible-tower cli 
pip install ansible-tower-cli

# Bootstrap tower from this branch
ansible-playbook -i /home/dimitra/integreatly/integreatly_dev/inventories/hosts playbooks/bootstrap.yml -e tower_environment=pds -e pds_tower_host=ansible-tower-web-svc-tower.apps.dimitra-80f4.open.redhat.com --ask-vault-pass
```
### Provision a PoC cluster 
- Log in to the tower instance (log in to the OCP3 cluster > tower namespace > tower route). Use the credentials `admin/CHANGEME`
- In templates, run the Cluster Provision workflow. Choose the `eu-west-2` region
- Once this is provisioned, you should have a cluster URL (e.g. `https://dimitraz.skunkhenry.com/`) and login credentials (e.g. `integreatly/<generated-password>`)

### Install integreatly
- From tower, run the Integreatly Install workflow. In the survey, you should see a new field prompting for the customer admin password. 
   - For openshift master URL, use the URL of the PoC cluster
   - For cluster admin username and password, use `opentlc-mgr/r3dh4t1!` (these credentials are used to log in to the PoC cluster) 
   - For customer admin password, choose any random password 
- Once the installation is complete, navigate to the PoC cluster URL
- You should now be redirected to the integreatly SSO login page. You should now be able to log in with `customer-admin` and the password you chose in the survey 