### PR TITLE
cleanup properly

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+set -e
+
+cleanup (){
+    oc login $OPENSHIFT_MASTER -u $TOWER_OPENSHIFT_USERNAME -p $TOWER_OPENSHIFT_PASSWORD
+    oc delete project ${TOWER_OPENSHIFT_PROJECT}
+}
+
+trap 'cleanup' EXIT
+
 echo "tower_openshift_project: '"$TOWER_OPENSHIFT_PROJECT"'" >> e2e_test_config.yml
 echo "tower_openshift_password: '"$TOWER_OPENSHIFT_PASSWORD"'" >> e2e_test_config.yml
 echo "tower_openshift_username: '"$TOWER_OPENSHIFT_USERNAME"'" >> e2e_test_config.yml
@@ -14,8 +23,6 @@ echo "Installing tower on openshift: ${TOWER_OPENSHIFT_PROJECT}"
 ansible-playbook -i ./inventories/hosts \
 playbooks/install_tower.yml \
 --extra-vars "@e2e_test_config.yml"
-install_exit_code=$?
-echo "Install playbook ansible exit code: $install_exit_code"
 
 #Pass environment variables to config file
 echo "e2e_tower_license: '"$TOWER_LICENSE"'" >> e2e_test_config.yml
@@ -26,10 +33,4 @@ echo "Bootstrapping tower in openshift project: ${TOWER_OPENSHIFT_PROJECT}"
 ansible-playbook -i ./inventories/hosts \
 playbooks/bootstrap.yml \
 --extra-vars "@e2e_test_config.yml"
-bootstrap_exit_code=$?
-echo "Bootstrap playbook ansible exit code: $bootstrap_exit_code"
 
-
-oc delete project ${TOWER_OPENSHIFT_PROJECT}
-exit_code=`expr $install_exit_code + $bootstrap_exit_code`
-exit $exit_code


### PR DESCRIPTION
**JIRA**
https://issues.redhat.com/browse/INTLY-5202

**What**
Improve the cleanup, don't let the script continue as it was doing before

**Verification**
Export the usual variables locally - reach out if you want a copy of those.
Cause a failure by setting the tower credentials incorrectly.
Run the local tests using the instructions in the README
The playbook will fail out and delete the project correctly 

Output should be 
```
Using project "tower-e2e-<gitref>".
project.project.openshift.io "tower-e2e-<gitref>" deleted
make: *** [test/e2e] Error 1
```

NOTE: Each one is pointing to the same cluster and we started to see some resource issues there. Please check that's not the issue if you face it.

