### PR TITLE
Remove acme_account check

### DIFF
--- a/playbooks/roles/cluster/tasks/provision_cluster.yml
+++ b/playbooks/roles/cluster/tasks/provision_cluster.yml
@@ -179,16 +179,6 @@
   #
   # LetsEncrypt cert generation
   #
-  - name: Make sure account exists and has given contacts. We agree to TOS.
-    acme_account:
-        account_key_content: "{{ letsencrypt_private_key }}"
-        state: present
-        terms_agreed: yes
-        acme_version: 2
-        acme_directory: "{{ acme_directory_url }}"
-        contact:
-        - mailto: "{{ cert_email_address }}"
-
   - name: Create directory for certs
     file:
         path: "/tmp/{{ oo_clusterid }}/certs"

--- a/playbooks/roles/cluster/templates/cluster_provision_survey.json.j2
+++ b/playbooks/roles/cluster/templates/cluster_provision_survey.json.j2
@@ -27,7 +27,7 @@
       {
       "question_description": "Flag for provisioning logging stack",
       "min": null,
-      "default": "true",
+      "default": "false",
       "max": null,
       "required": true,
       "choices": "true\nfalse",


### PR DESCRIPTION
This is failing now for some reason but is in fact only checking that the account exists. We can ignore it and continue on, if the account does not exist it will fail when trying to generate the cert but it would have failed here then too anyway.

Successful job run here: https://eng-tower.rhmw.io/#/workflows/2734