### PR TITLE
Inventory source fix for sre

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -4,6 +4,8 @@
   tasks:
     - include_vars:
         ./roles/tower/defaults/main.yml
+    - include_vars:
+        ./roles/cluster/defaults/main.yml
 
     - name: "Confirmation prompt for bootstrapping master"
       pause:

--- a/playbooks/roles/cluster/tasks/bootstrap_cluster_create.yml
+++ b/playbooks/roles/cluster/tasks/bootstrap_cluster_create.yml
@@ -1,21 +1,4 @@
 ---
-- name: "Create inventory source from Project: {{ tower_credentials_project_name}}"
-  tower_inventory_source:
-    name: "{{ cluster_inventory_source_project_name }}"
-    source: "{{ cluster_inventory_source_project_type }}"
-    inventory: "{{ tower_inventory_name }}"
-    description: "From Project: {{ tower_credentials_project_name }}"
-    overwrite: "{{ cluster_inventory_source_project_overwrite }}"
-    overwrite_vars: "{{ cluster_inventory_source_project_overwrite_vars }}"
-    update_on_launch: "{{ cluster_inventory_source_project_update_on_launch }}"
-    source_project: "{{ tower_credentials_project_name }}"
-    source_path: "{{ cluster_inventory_source_project_path }}"
-    state: present
-    tower_verify_ssl: '{{ tower_verify_ssl }}'
-
-- name: "Sync inventory sources"
-  shell: "tower-cli inventory_source update {{ cluster_inventory_source_project_name }}"
-
 - name: "Create the tower {{ tower_secret_organization }} organisation"
   tower_organization:
     name: "{{ tower_secret_organization }}"

--- a/playbooks/roles/tower/tasks/bootstrap.yml
+++ b/playbooks/roles/tower/tasks/bootstrap.yml
@@ -70,6 +70,23 @@
 # Import the credentials bootstrap task
 - include_tasks: bootstrap_projects.yml
 
+- name: "Create inventory source from Project: {{ tower_credentials_project_name}}"
+  tower_inventory_source:
+    name: "{{ cluster_inventory_source_project_name }}"
+    source: "{{ cluster_inventory_source_project_type }}"
+    inventory: "{{ tower_inventory_name }}"
+    description: "From Project: {{ tower_credentials_project_name }}"
+    overwrite: "{{ cluster_inventory_source_project_overwrite }}"
+    overwrite_vars: "{{ cluster_inventory_source_project_overwrite_vars }}"
+    update_on_launch: "{{ cluster_inventory_source_project_update_on_launch }}"
+    source_project: "{{ tower_credentials_project_name }}"
+    source_path: "{{ cluster_inventory_source_project_path }}"
+    state: present
+    tower_verify_ssl: '{{ tower_verify_ssl }}'
+
+- name: "Sync inventory sources"
+  shell: "tower-cli inventory_source update {{ cluster_inventory_source_project_name }}"
+
 # Import Job Template bootstrapping
 - include_tasks: bootstrap_jobs.yml
 


### PR DESCRIPTION
SRE saw an issue where the authenticate_tower job couldn't be created since the inventory source didn't exist. The inventory source is created in the cluster_create job hence why they didn't get to there, this PR moves the inventory source creation to the bootstrap playbook so that it happens right after the credential repository is created